### PR TITLE
Adjust format for bearer token authorization

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -74,7 +74,7 @@ module Fluent
       if @bearer_token_file.present?
         bearer_token = File.read(@bearer_token_file)
         RestClient.add_before_execution_proc do |req, params|
-          req['authorization'] ||= "Bearer #{bearer_token}"
+          req['Authorization'] ||= "Bearer: #{bearer_token}"
         end
       end
 


### PR DESCRIPTION
No idea if this is right, but perhaps it will help me avoid getting this error:
```
2015-05-12 00:57:10 +0000 [info]: adding filter pattern="labels.**" type="kubernetes_metadata"
2015-05-12 00:57:10 +0000 [error]: config error file="/etc/td-agent/td-agent.conf" error="Invalid Kubernetes API 
endpoint: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed"
2015-05-12 00:57:10 +0000 [info]: process finished code=256
2015-05-12 00:57:10 +0000 [warn]: process died within 1 second. exit.
```