### PR TITLE
Updating logic to retrieve cache_key

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -123,7 +123,7 @@ module Fluent
         }
 
         if @kubernetes_url.present?
-          cache_key = "#{metadata['namespace']}_#{metadata['pod_name']}_#{metadata['pod_container_name']}"
+          cache_key = "#{metadata[:kubernetes][:namespace]}_#{metadata[:kubernetes][:pod_name]}_#{metadata[:kubernetes][:container_name]}"
 
           if cache_key.present?
             this                = self


### PR DESCRIPTION
Previous logic wasn't pulling out values and resulting cache_key would be '___'  causing metadata values to be overwritten in the following block.