### PR TITLE
Don't overwrite the simple namespace/pod/container metadata if we're

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -129,11 +129,12 @@ module Fluent
             this                = self
             metadata            = @cache.getset(cache_key) {
               if metadata
-                metadata[:kubernetes] = this.get_metadata(
+                kubernetes_metadata = this.get_metadata(
                     metadata[:kubernetes][:pod_name],
                     metadata[:kubernetes][:container_name],
                     metadata[:kubernetes][:namespace]
                 )
+                metadata[:kubernetes] = kubernetes_metadata if kubernetes_metadata
                 metadata
               end
             }


### PR DESCRIPTION
unable to load the more complete metadata.

The first of a couple small changes I plan to make, this one mostly just to make sure my development environment works.

@jimmidyson 