### PR TITLE
retain original log record from JSONL format

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -169,11 +169,7 @@ module Fluent
         log = record['log'].strip
         if log[0].eql?('{') && log[-1].eql?('}')
           begin
-            parsed_log = JSON.parse(log)
-            record     = record.merge(parsed_log)
-            unless parsed_log.has_key?('log')
-              record.delete('log')
-            end
+            record = JSON.parse(log).merge(record)
           rescue JSON::ParserError
           end
         end

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -248,7 +248,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
         'log' => "#{json_log.to_json}"
       }
       es = emit_with_tag('non-kubernetes', msg, '')
-      assert_equal(json_log, es.instance_variable_get(:@record_array)[0])
+      assert_equal(msg.merge(json_log), es.instance_variable_get(:@record_array)[0])
     end
   end
 end


### PR DESCRIPTION
merge_json_log detects and parses JSON-format log lines in order
to add their fields as first-class citizens. However it was removing
the original log message and potentially overwriting other fields.
Now it ensures that the original log fields are retained.