### PR TITLE
Use Kubernetes services account if possible

### DIFF
--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", "~> 0.12.0"
   gem.add_runtime_dependency "lru_redux"
   gem.add_runtime_dependency "kubeclient", "~> 0.4.0"
   gem.add_runtime_dependency "fluent-plugin-docker_metadata_filter"


### PR DESCRIPTION
If fluentd is running in a pod, it has sufficient access to the
Kubernetes API to enrich log records with pod and namespace metadata.
When URL / token / etc. are not implicitly specified, try and grab the
service account's credentials from the well-known directory.

Issue #12