### PR TITLE
Only call strip() if the object has that method.

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -315,7 +315,10 @@ module Fluent
 
     def merge_json_log(record)
       if record.has_key?(@merge_json_log_key)
-        log = record[@merge_json_log_key].strip
+        log = record[@merge_json_log_key]
+        if log.respond_to?(:strip)
+          log = log.strip
+        end
         if log[0].eql?('{') && log[-1].eql?('}')
           begin
             record = JSON.parse(log).merge(record)


### PR DESCRIPTION
Symbols don't have it and sometimes we get those instead of strings.