### PR TITLE
Fix compatibility with fluentd v0.14

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -196,6 +196,10 @@ module Fluent
       end
 
     end
+    
+    def filter(tag, time, record)
+      record
+    end
 
     def filter_stream_from_files(tag, es)
       new_es = MultiEventStream.new


### PR DESCRIPTION
v0.14 requires a filter method, it implodes if there isn't one