### PR TITLE
Fixed use example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Reading from the JSON formatted log files with `in_tail` and wildcard filenames:
   read_from_head true
 </source>
 
-<filter kubernetes.var.lib.docker.containers.*.*.log>
+<filter kubernetes.var.log.containers.*.log>
   type kubernetes_metadata
 </filter>
 


### PR DESCRIPTION
The use example on the README file asks to filter kubernetes.var.lib.docker.containers.*.*.log. That filter is wrong, the correct one is kubernetes.var.log.containers.*.log.
That path correlates to a docker install, which by default uses the path /var/lib/docker/containers/[hash]/[hash]-json.log, but in a kubernetes install the correct path is /var/log/containers/*.log