### PR TITLE
thread safety fix: do not mutate cached object

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -221,16 +221,17 @@ module Fluent
           cache_key = "#{metadata['kubernetes']['namespace_name']}_#{metadata['kubernetes']['pod_name']}"
 
           this     = self
-          metadata = @cache.getset(cache_key) {
+          kubernetes_metadata = @cache.getset(cache_key) {
             if metadata
-              kubernetes_metadata = this.get_metadata(
+              md = this.get_metadata(
                 metadata['kubernetes']['namespace_name'],
                 metadata['kubernetes']['pod_name']
               )
-              metadata['kubernetes'] = kubernetes_metadata if kubernetes_metadata
-              metadata
+              md
             end
           }
+          metadata['kubernetes'].merge!(kubernetes_metadata) if kubernetes_metadata
+
           if @include_namespace_id
             namespace_name = metadata['kubernetes']['namespace_name']
             namespace_id = @namespace_cache.getset(namespace_name) {
@@ -277,16 +278,17 @@ module Fluent
               cache_key = "#{metadata['kubernetes']['namespace_name']}_#{metadata['kubernetes']['pod_name']}"
 
               this     = self
-              metadata = @cache.getset(cache_key) {
+              kubernetes_metadata = @cache.getset(cache_key) {
                 if metadata
-                  kubernetes_metadata = this.get_metadata(
+                  md = this.get_metadata(
                     metadata['kubernetes']['namespace_name'],
                     metadata['kubernetes']['pod_name']
                   )
-                  metadata['kubernetes'] = kubernetes_metadata if kubernetes_metadata
-                  metadata
+                  md
                 end
               }
+              metadata['kubernetes'].merge!(kubernetes_metadata) if kubernetes_metadata
+
               if @include_namespace_id
                 namespace_name = metadata['kubernetes']['namespace_name']
                 namespace_id = @namespace_cache.getset(namespace_name) {
@@ -375,8 +377,8 @@ module Fluent
                 self.de_dot!(labels)
                 self.de_dot!(annotations)
               end
-              cached['kubernetes']['labels'] = labels
-              cached['kubernetes']['annotations'] = annotations
+              cached['labels'] = labels
+              cached['annotations'] = annotations
               @cache[cache_key] = cached
             end
           when 'DELETED'


### PR DESCRIPTION
By setting 'container_name' on the metadata object returned by
`@cache.getset`, we create a race condition where containers
in the same pod will end up with an incorrect 'container_name'
assigned.

In the old code `metadata['kubernetes']` was effectively shared
for all records within a pod, so the 'container_name' that ends
up in the final record was determined by whichever record happened
to set 'container_name' last.

Instead, merge the cached object into the metadata that we create
for each record.