### PR TITLE
Fix config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Reading from the JSON formatted log files with `in_tail` and wildcard filenames:
   read_from_head true
 </source>
 
-<filter kubernetes.var.log.containers.*.log>
+<filter kubernetes.var.log.containers.**.log>
   type kubernetes_metadata
 </filter>
 


### PR DESCRIPTION
The previous example would skip containers with a dot in the name.

Fixes #58
Followup on https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/issues/35