### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.has_rdoc      = false
 
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = '>= 2.1.0'
 
-  gem.add_runtime_dependency "fluentd", ">= 0.12.0"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   gem.add_runtime_dependency "lru_redux"
   gem.add_runtime_dependency "kubeclient", "~> 1.1.4"
 

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -17,8 +17,10 @@
 # limitations under the License.
 #
 require_relative 'kubernetes_metadata_stats'
-module Fluent
-  class KubernetesMetadataFilter < Fluent::Filter
+require 'fluent/plugin/filter'
+
+module Fluent::Plugin
+  class KubernetesMetadataFilter < Fluent::Plugin::Filter
     K8_POD_CA_CERT = 'ca.crt'
     K8_POD_TOKEN = 'token'
 
@@ -310,7 +312,7 @@ module Fluent
     end
 
     def filter_stream_from_files(tag, es)
-      new_es = MultiEventStream.new
+      new_es = Fluent::MultiEventStream.new
 
       match_data = tag.match(@tag_to_kubernetes_name_regexp_compiled)
 
@@ -339,7 +341,7 @@ module Fluent
     end
 
     def filter_stream_from_journal(tag, es)
-      new_es = MultiEventStream.new
+      new_es = Fluent::MultiEventStream.new
 
       es.each { |time, record|
         record = merge_json_log(record) if @merge_json_log


### PR DESCRIPTION
If fluentd plugins use and inherits its class v0.14 API, Fluentd permits to send nanosecond precision time and append time zone information.
If this patches are acceptable for this plugin developers, please review carefully and follow this upgrading from v0.12 (old style) guideline: http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12

Kind regards,