### PR TITLE
Master url metadata

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -71,7 +71,7 @@ module Fluent
       newhsh
     end
 
-    def get_metadata(namespace_name, pod_name)
+    def get_metadata(namespace_name, pod_name, master_url)
       begin
         metadata = @client.get_pod(pod_name, namespace_name)
         return if !metadata
@@ -86,7 +86,8 @@ module Fluent
             'pod_id'         => metadata['metadata']['uid'],
             'pod_name'       => pod_name,
             'labels'         => labels,
-            'host'           => metadata['spec']['nodeName']
+            'host'           => metadata['spec']['nodeName'],
+            'master_url'     => master_url
         }
         kubernetes_metadata['annotations'] = annotations unless annotations.empty?
         return kubernetes_metadata
@@ -225,7 +226,8 @@ module Fluent
             if metadata
               md = this.get_metadata(
                 metadata['kubernetes']['namespace_name'],
-                metadata['kubernetes']['pod_name']
+                metadata['kubernetes']['pod_name'],
+                @kubernetes_url
               )
               md
             end
@@ -282,7 +284,8 @@ module Fluent
                 if metadata
                   md = this.get_metadata(
                     metadata['kubernetes']['namespace_name'],
-                    metadata['kubernetes']['pod_name']
+                    metadata['kubernetes']['pod_name'],
+                    @kubernetes_url
                   )
                   md
                 end

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -166,6 +166,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'container_name' => 'fabric8-console-container',
             'namespace_name' => 'default',
             'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'     => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -194,6 +195,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'     => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -221,6 +223,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'container_name' => 'fabric8-console-container',
             'namespace_name' => 'default',
             'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'     => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -388,6 +391,7 @@ use_journal true
             'container_name' => 'fabric8-console-container',
             'namespace_name' => 'default',
             'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'     => 'https://localhost:8443',
             'labels' => {
               'kubernetes_io/test' => 'somevalue'
             }
@@ -415,6 +419,7 @@ use_journal true
             'container_name' => 'fabric8-console-container',
             'namespace_name' => 'default',
             'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'     => 'https://localhost:8443',
             'labels' => {
               'kubernetes.io/test' => 'somevalue'
             }
@@ -457,6 +462,7 @@ use_journal true
             'container_name' => 'fabric8-console-container',
             'namespace_name' => 'default',
             'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'     => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -493,6 +499,7 @@ use_journal true
             'namespace_name' => 'default',
             'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'     => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -520,6 +527,7 @@ use_journal true
                 'container_name' => 'fabric8-console-container',
                 'namespace_name' => 'default',
                 'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+                'master_url'     => 'https://localhost:8443',
                 'labels'         => {
                     'component' => 'fabric8Console'
                 },


### PR DESCRIPTION
Added master_url to the meta-data so one is able to detect the cluster a pod is running in case of multi-cluster setups.

The pull request is related with the following feature request reported earlier today by myself...
https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/69

Example:

	{"CONTAINER_ID_FULL"=>
	  "49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459",
	 "CONTAINER_NAME"=>
	  "k8s_fabric8-console-container.db89db89_fabric8-console-controller-98rqc_default_c76927af-f563-11e4-b32d-54ee7527188d_89db89db",
	 "docker"=>
	  {"container_id"=>
		"49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459"},
	 "kubernetes"=>
	  {"container_name"=>"fabric8-console-container",
	   "host"=>"jimmi-redhat.localnet",
	   "labels"=>{"component"=>"fabric8Console"},
	   "master_url"=>"https://localhost:8443",
	   "namespace_name"=>"default",
	   "pod_id"=>"c76927af-f563-11e4-b32d-54ee7527188d",
	   "pod_name"=>"fabric8-console-controller-98rqc"},
	 "randomfield"=>"randomvalue"}