### PR TITLE
Let user know more on kubernetes comminication error

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -361,7 +361,12 @@ module Fluent
         resource_version = @client.get_pods.resourceVersion
         watcher          = @client.watch_pods(resource_version)
       rescue Exception => e
-        raise Fluent::ConfigError, "Exception encountered fetching metadata from Kubernetes API endpoint: #{e.message}"
+        message = "Exception encountered fetching metadata from Kubernetes API endpoint: #{e.message}"
+        if e.respond_to?(:response)
+          message += " (#{e.response})"
+        end
+
+        raise Fluent::ConfigError, message
       end
 
       watcher.each do |notice|


### PR DESCRIPTION
I've been installing fluentd to kubernetes and got error 403 without further explanation of what is wrong. Had to build own image in order to debug this behaviour... 

Here is corresponding fluentd issue: https://github.com/fluent/fluentd-kubernetes-daemonset/issues/14