### PR TITLE
Removed logging of namespace watch events

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -405,7 +405,6 @@ module Fluent
       resource_version = @client.get_namespaces.resourceVersion
       watcher          = @client.watch_namespaces(resource_version)
       watcher.each do |notice|
-        puts notice
         case notice.type
           when 'MODIFIED'
             cache_key = notice.object['metadata']['name']


### PR DESCRIPTION
In a busy cluster e.g. when running e2e test suite logging every event gets quite noisy.