### PR TITLE
deep copy metadata in filter_stream_from_files

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -285,7 +285,7 @@ module Fluent
       es.each { |time, record|
         record = merge_json_log(record) if @merge_json_log
 
-        record = record.merge(metadata) if metadata
+        record = record.merge(Marshal.load(Marshal.dump(metadata))) if metadata
 
         new_es.add(time, record)
       }


### PR DESCRIPTION
This change makes deep copy of the metadata, along with kubernetes and docker fields, to ensure they are unique per record and changeable.

As currently implemented, filter_stream_from_files method creates a Hash 'metadata' for multiple records simultaneously and `Hash::merge` does only a shallow copy of the Hash. If any other filter in the pipeline then attempts to change anything in the `'kubernetes'` or `'docker'` fields, change gets propagated to the related records sharing fluentd tag.

Another approach could be moving [this block of code](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/blob/master/lib/fluent/plugin/filter_kubernetes_metadata.rb#L272-L283) to the loop [right before metadata are merged](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/blob/master/lib/fluent/plugin/filter_kubernetes_metadata.rb#L287).

cc: @richm , @josefkarasek