### PR TITLE
refactor cache to use different keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 [![Code Climate](https://codeclimate.com/github/fabric8io/fluent-plugin-kubernetes_metadata_filter/badges/gpa.svg)](https://codeclimate.com/github/fabric8io/fluent-plugin-kubernetes_metadata_filter)
 [![Test Coverage](https://codeclimate.com/github/fabric8io/fluent-plugin-kubernetes_metadata_filter/badges/coverage.svg)](https://codeclimate.com/github/fabric8io/fluent-plugin-kubernetes_metadata_filter)
 
+The Kubernetes metadata plugin filter enriches container log records with pod and namespace metadata.
+
+This plugin derives basic metadata about the container that emitted a given log record using the source of the log record. Records from journald provide metadata about the
+container environment as named fields. Records from JSON files encode metadata about the container in the file name.  The initial metadata derived from the source is used
+to lookup additional metadata about the container's associated pod and namespace (e.g. UUIDs, labels, annotations) when the kubernetes_url is configured.  If the plugin cannot
+authoritatively determine the namespace of the container emitting a log record, it will use an 'orphan' namespace ID in the metadata. This behaviors supports multi-tenant systems
+that rely on the authenticity of the namespace for proper log isolation.
+
 ## Installation
 
     gem install fluent-plugin-kubernetes_metadata_filter
@@ -33,6 +41,10 @@ This must used named capture groups for `container_name`, `pod_name` & `namespac
 * `include_namespace_metadata` - Collect metadata about namespace such as uid, labels and annotations (default: `false`).  
   Note that when this option is enabled, all label from namespace are collected, but annotations are collected according to `annotation_match` value. If `annotation_match` is not presented, no annotations will be collected from the namespace.
 * `annotation_match` - Array of regular expressions matching annotation field names. Matched annotations are added to a log record.
+* `allow_orphans` - Modify the namespace and namespace id to the values of `orphaned_namespace_name` and `orphaned_namespace_id`
+when true (default: `true`)
+* `orphaned_namespace_name` - The namespace to associate with records where the namespace can not be determined (default: `.orphaned`)
+* `orphaned_namespace_id` - The namespace id to associate with records where the namespace can not be determined (default: `orphaned`)
 
 Reading from the JSON formatted log files with `in_tail` and wildcard filenames:
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -23,11 +23,11 @@ task :headers do
   require 'copyright_header'
 
   args = {
-    :license => 'ASL2',
+    :license => 'Apache-2.0',
     :copyright_software => 'Fluentd Kubernetes Metadata Filter Plugin',
     :copyright_software_description => 'Enrich Fluentd events with Kubernetes metadata',
     :copyright_holders => ['Red Hat, Inc.'],
-    :copyright_years => ['2015'],
+    :copyright_years => ['2015-2017'],
     :add_path => 'lib:test',
     :output_dir => '.'
   }

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Jimmi Dyson"]
   gem.email         = ["jimmidyson@gmail.com"]
   gem.description   = %q{Filter plugin to add Kubernetes metadata}
-  gem.summary       = %q{Filter plugin to add Kubernetes metadata}
+  gem.summary       = %q{Fluentd filter plugin to add Kubernetes metadata}
   gem.homepage      = "https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter"
-  gem.license       = "ASL2"
+  gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/fluent/plugin/kubernetes_metadata_common.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_common.rb
@@ -1,0 +1,85 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module KubernetesMetadata
+  module Common
+
+    def match_annotations(annotations)
+      result = {}
+      @annotations_regexps.each do |regexp|
+        annotations.each do |key, value|
+          if ::Fluent::StringUtil.match_regexp(regexp, key.to_s)
+            result[key] = value
+          end
+        end
+      end
+      result
+    end
+
+    def parse_namespace_metadata(namespace_object)
+      labels = syms_to_strs(namespace_object['metadata']['labels'].to_h)
+      annotations = match_annotations(syms_to_strs(namespace_object['metadata']['annotations'].to_h))
+      if @de_dot
+        self.de_dot!(labels)
+        self.de_dot!(annotations)
+      end
+      kubernetes_metadata = {
+        'namespace_id' => namespace_object['metadata']['uid'],
+        'creation_timestamp' => namespace_object['metadata']['creationTimestamp']
+      }
+      kubernetes_metadata['namespace_labels'] = labels unless labels.empty?
+      kubernetes_metadata['namespace_annotations'] = annotations unless annotations.empty?
+      return kubernetes_metadata
+    end
+
+    def parse_pod_metadata(pod_object)
+      labels = syms_to_strs(pod_object['metadata']['labels'].to_h)
+      annotations = match_annotations(syms_to_strs(pod_object['metadata']['annotations'].to_h))
+      if @de_dot
+        self.de_dot!(labels)
+        self.de_dot!(annotations)
+      end
+      kubernetes_metadata = {
+          'namespace_name' => pod_object['metadata']['namespace'],
+          'pod_id'         => pod_object['metadata']['uid'],
+          'pod_name'       => pod_object['metadata']['name'],
+          'labels'         => labels,
+          'host'           => pod_object['spec']['nodeName'],
+          'master_url'     => @kubernetes_url
+      }
+      kubernetes_metadata['annotations'] = annotations unless annotations.empty?
+      return kubernetes_metadata
+    end
+
+    def syms_to_strs(hsh)
+      newhsh = {}
+      hsh.each_pair do |kk,vv|
+        if vv.is_a?(Hash)
+          vv = syms_to_strs(vv)
+        end
+        if kk.is_a?(Symbol)
+          newhsh[kk.to_s] = vv
+        else
+          newhsh[kk] = vv
+        end
+      end
+      newhsh
+    end
+
+  end
+end

--- a/lib/fluent/plugin/kubernetes_metadata_stats.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_stats.rb
@@ -2,7 +2,7 @@
 # Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
 # Kubernetes metadata
 #
-# Copyright 2015 Red Hat, Inc.
+# Copyright 2017 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ module KubernetesMetadata
   class Stats
 
     def initialize
-      @stats = LruRedux::TTL::ThreadSafeCache.new(1000, 3600)
+      @stats = ::LruRedux::TTL::ThreadSafeCache.new(1000, 3600)
     end
 
     def bump(key)
@@ -30,6 +30,10 @@ module KubernetesMetadata
 
     def set(key, value)
        @stats[key] = value
+    end
+
+    def [](key)
+      @stats[key]
     end
 
     def to_s

--- a/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
@@ -1,0 +1,60 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'kubernetes_metadata_common'
+
+module KubernetesMetadata
+  module WatchNamespaces
+
+    include ::KubernetesMetadata::Common
+
+    def start_namespace_watch
+      begin
+        resource_version = @client.get_namespaces.resourceVersion
+        watcher          = @client.watch_namespaces(resource_version)
+      rescue Exception=>e
+        message = "start_namespace_watch: Exception encountered setting up namespace watch from Kubernetes API #{@apiVersion} endpoint #{@kubernetes_url}: #{e.message}"
+        message += " (#{e.response})" if e.respond_to?(:response)
+        log.debug(message)
+        raise Fluent::ConfigError, message
+      end
+      watcher.each do |notice|
+        case notice.type
+          when 'MODIFIED'
+            cache_key = notice.object['metadata']['uid']
+            cached    = @namespace_cache[cache_key]
+            if cached
+              @namespace_cache[cache_key] = parse_namespace_metadata(notice.object)
+              @stats.bump(:namespace_cache_watch_updates)
+            else
+              @stats.bump(:namespace_cache_watch_misses)
+            end
+          when 'DELETED'
+            # ignore and let age out for cases where 
+            # deleted but still processing logs
+            @stats.bump(:namespace_cache_watch_deletes_ignored)
+          else
+            # Don't pay attention to creations, since the created namespace may not
+            # be used by any pod on this node.
+            @stats.bump(:namespace_cache_watch_ignored)
+        end
+      end
+    end
+
+  end
+end

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -1,0 +1,60 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'kubernetes_metadata_common'
+
+module KubernetesMetadata
+  module WatchPods
+
+    include ::KubernetesMetadata::Common
+
+    def start_pod_watch
+      begin
+        resource_version = @client.get_pods.resourceVersion
+        watcher          = @client.watch_pods(resource_version)
+      rescue Exception => e
+        message = "Exception encountered fetching metadata from Kubernetes API endpoint: #{e.message}"
+        message += " (#{e.response})" if e.respond_to?(:response)
+
+        raise Fluent::ConfigError, message
+      end
+
+      watcher.each do |notice|
+        case notice.type
+          when 'MODIFIED'
+            cache_key = notice.object['metadata']['uid']
+            cached    = @cache[cache_key]
+            if cached
+              @cache[cache_key] = parse_pod_metadata(notice.object)
+              @stats.bump(:pod_cache_watch_updates)
+            else
+              @stats.bump(:pod_cache_watch_misses)
+            end
+          when 'DELETED'
+            # ignore and let age out for cases where pods
+            # deleted but still processing logs
+            @stats.bump(:pod_cache_watch_delete_ignored)
+          else
+            # Don't pay attention to creations, since the created pod may not
+            # end up on this node.
+            @stats.bump(:pod_cache_watch_ignored)
+        end
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,6 +30,7 @@ require 'test/unit/rr'
 require 'fileutils'
 require 'fluent/log'
 require 'fluent/test'
+require 'minitest/autorun'
 require 'webmock/test_unit'
 require 'vcr'
 

--- a/test/plugin/test_watch_namespaces.rb
+++ b/test/plugin/test_watch_namespaces.rb
@@ -1,0 +1,91 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative '../helper'
+require 'ostruct'
+require_relative 'watch_test'
+
+class WatchNamespacesTestTest < WatchTest
+
+     include KubernetesMetadata::WatchNamespaces
+
+     setup do
+       @created = OpenStruct.new(
+         type: 'CREATED',
+         object: {
+           'metadata' => {
+                'name' => 'created',
+                'uid' => 'created_uid'
+            }
+         }
+       )
+       @modified = OpenStruct.new(
+         type: 'MODIFIED',
+         object: {
+           'metadata' => {
+                'name' => 'foo',
+                'uid' => 'modified_uid'
+            }
+         }
+       )
+       @deleted = OpenStruct.new(
+         type: 'DELETED',
+         object: {
+           'metadata' => {
+                'name' => 'deleteme',
+                'uid' => 'deleted_uid'
+            }
+         }
+       )
+     end
+
+    test 'namespace watch ignores CREATED' do
+      @client.stub :watch_namespaces, [@created] do
+       start_namespace_watch
+       assert_equal(false, @namespace_cache.key?('created_uid'))
+       assert_equal(1, @stats[:namespace_cache_watch_ignored])
+      end
+    end
+
+    test 'namespace watch ignores MODIFIED when info not in cache' do
+      @client.stub :watch_namespaces, [@modified] do
+       start_namespace_watch
+       assert_equal(false, @namespace_cache.key?('modified_uid'))
+       assert_equal(1, @stats[:namespace_cache_watch_misses])
+      end
+    end
+
+    test 'namespace watch updates cache when MODIFIED is received and info is cached' do
+      @namespace_cache['modified_uid'] = {}
+      @client.stub :watch_namespaces, [@modified] do
+       start_namespace_watch
+       assert_equal(true, @namespace_cache.key?('modified_uid'))
+       assert_equal(1, @stats[:namespace_cache_watch_updates])
+      end
+    end
+
+    test 'namespace watch ignores DELETED' do
+      @namespace_cache['deleted_uid'] = {}
+      @client.stub :watch_namespaces, [@deleted] do
+       start_namespace_watch
+       assert_equal(true, @namespace_cache.key?('deleted_uid'))
+       assert_equal(1, @stats[:namespace_cache_watch_deletes_ignored])
+      end
+    end
+
+end

--- a/test/plugin/test_watch_pods.rb
+++ b/test/plugin/test_watch_pods.rb
@@ -1,0 +1,102 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative '../helper'
+require 'ostruct'
+require_relative 'watch_test'
+
+class DefaultPodWatchStrategyTest < WatchTest
+
+     include KubernetesMetadata::WatchPods
+
+     setup do
+       @created = OpenStruct.new(
+         type: 'CREATED',
+         object: {
+           'metadata' => {
+                'name' => 'created',
+                'namespace' => 'create',
+                'uid' => 'created_uid',
+                'labels' => {},
+            },
+            'spec' => {
+                'nodeName' => 'aNodeName'
+            }
+         }
+       )
+       @modified = OpenStruct.new(
+         type: 'MODIFIED',
+         object: {
+           'metadata' => {
+                'name' => 'foo',
+                'namespace' => 'modified',
+                'uid' => 'modified_uid',
+                'labels' => {},
+            },
+            'spec' => {
+                'nodeName' => 'aNodeName'
+            }
+         }
+       )
+       @deleted = OpenStruct.new(
+         type: 'DELETED',
+         object: {
+           'metadata' => {
+                'name' => 'deleteme',
+                'namespace' => 'deleted',
+                'uid' => 'deleted_uid'
+            }
+         }
+       )
+     end
+
+    test 'pod watch notice ignores CREATED' do
+      @client.stub :watch_pods, [@created] do
+       start_pod_watch
+       assert_equal(false, @cache.key?('created_uid'))
+       assert_equal(1, @stats[:pod_cache_watch_ignored])
+      end
+    end
+
+    test 'pod watch notice is ignored when info not cached and MODIFIED is received' do
+      @client.stub :watch_pods, [@modified] do
+       start_pod_watch
+       assert_equal(false, @cache.key?('modified_uid'))
+       assert_equal(1, @stats[:pod_cache_watch_misses])
+      end
+    end
+
+    test 'pod watch notice is updated when MODIFIED is received' do
+      @cache['modified_uid'] = {}
+      @client.stub :watch_pods, [@modified] do
+       start_pod_watch
+       assert_equal(true, @cache.key?('modified_uid'))
+       assert_equal(1, @stats[:pod_cache_watch_updates])
+      end
+    end
+
+    test 'pod watch notice is ignored when delete is received' do
+      @cache['deleted_uid'] = {}
+      @client.stub :watch_pods, [@deleted] do
+       start_pod_watch
+       assert_equal(true, @cache.key?('deleted_uid'))
+       assert_equal(1, @stats[:pod_cache_watch_delete_ignored])
+      end
+    end
+
+end

--- a/test/plugin/watch_test.rb
+++ b/test/plugin/watch_test.rb
@@ -1,0 +1,57 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative '../helper'
+require 'ostruct'
+
+class WatchTest < Test::Unit::TestCase
+   
+    setup do
+      @annotations_regexps = []
+      @namespace_cache = {}
+      @cache = {}
+      @stats = KubernetesMetadata::Stats.new
+      @client = OpenStruct.new
+      def @client.resourceVersion
+        '12345'
+      end
+      def @client.watch_pods(value)
+         []
+      end
+      def @client.watch_namespaces(value)
+         []
+      end
+      def @client.get_namespaces 
+          self
+      end
+      def @client.get_pods
+          self
+      end
+    end
+
+    def watcher=(value)
+    end
+
+    def log
+        logger = {}
+        def logger.debug(message)
+        end
+        logger
+    end
+
+end


### PR DESCRIPTION
The PR refactors the cache impl to:

* Use pod and namespace uid
* handle orphaned records when applicable
