### PR TITLE
have to load lru_redux before using it

### DIFF
--- a/lib/fluent/plugin/kubernetes_metadata_stats.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_stats.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'lru_redux'
 module KubernetesMetadata
   class Stats
 


### PR DESCRIPTION
This allows fluentd to start - it fixes this problem:
```
2017-11-08 03:05:49 +0000 [error]: unexpected error error="uninitialized constant KubernetesMetadata::Stats::LruRedux"
  2017-11-08 03:05:49 +0000 [error]: /etc/fluent/plugin/kubernetes_metadata_stats.rb:23:in `initialize'
```
I have no idea why unit tests do not have this problem - lru_cache is being pulled in somewhere else.