### PR TITLE
Fixed bug with logging in merge_json_log

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -381,10 +381,10 @@ module Fluent
 
     def merge_json_log(record)
       if record.has_key?(@merge_json_log_key)
-        log = record[@merge_json_log_key].strip
-        if log[0].eql?('{') && log[-1].eql?('}')
+        value = record[@merge_json_log_key].strip
+        if value[0].eql?('{') && value[-1].eql?('}')
           begin
-            record = JSON.parse(log).merge(record)
+            record = JSON.parse(value).merge(record)
             unless @preserve_json_log
               record.delete(@merge_json_log_key)
             end

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -350,6 +350,15 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
       assert_equal(msg.merge(json_log), es.instance_variable_get(:@record_array)[0])
     end
 
+    test 'ignores invalid json in log field' do
+      json_log = "{'foo':123}"
+      msg = {
+          'log' => json_log
+      }
+      es = emit_with_tag('non-kubernetes', msg, '')
+      assert_equal(msg, es.instance_variable_get(:@record_array)[0])
+    end
+
     test 'merges json log data with message field in MESSAGE' do
       json_log = {
         'timeMillis' => 1459853347608,


### PR DESCRIPTION
Log message is parsed into `log` variable, which overrides method `log()` from [PluginLoggerMixin](http://www.rubydoc.info/gems/fluentd/0.12.40/Fluent/PluginLoggerMixin#log-instance_method), which is later used for debug logging:

```
2017-11-29 10:57:18 +0000 [warn]: emit transaction failed: error_class=NoMethodError error="undefined method `debug' for #<String:0x000000021db288>" tag="kubernetes.var.log.containers.service-name-2004446547-54rqk_default_service-7615f5fc09651062d46c426c9f45f80c110e072e58275b0e745495567c450301.log"
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluent-plugin-kubernetes_metadata_filter-0.32.0/lib/fluent/plugin/filter_kubernetes_metadata.rb:394:in `rescue in merge_json_log'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluent-plugin-kubernetes_metadata_filter-0.32.0/lib/fluent/plugin/filter_kubernetes_metadata.rb:387:in `merge_json_log'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluent-plugin-kubernetes_metadata_filter-0.32.0/lib/fluent/plugin/filter_kubernetes_metadata.rb:331:in `block in filter_stream_from_files'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/event.rb:130:in `call'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/event.rb:130:in `block in each'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/event.rb:129:in `each'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/event.rb:129:in `each'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluent-plugin-kubernetes_metadata_filter-0.32.0/lib/fluent/plugin/filter_kubernetes_metadata.rb:330:in `filter_stream_from_files'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/event_router.rb:152:in `block in emit'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/event_router.rb:151:in `each'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/event_router.rb:151:in `emit'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/event_router.rb:90:in `emit_stream'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:311:in `receive_lines'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:429:in `call'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:429:in `wrap_receive_lines'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:626:in `call'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:626:in `on_notify'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:455:in `on_notify'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:435:in `attach'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:208:in `setup_watcher'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:226:in `block in start_watchers'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:213:in `each'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:213:in `start_watchers'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:202:in `refresh_watchers'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:542:in `call'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:542:in `on_timer'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/cool.io-1.5.1/lib/cool.io/loop.rb:88:in `run_once'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/cool.io-1.5.1/lib/cool.io/loop.rb:88:in `run'
  2017-11-29 10:57:18 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.2.0/gems/fluentd-0.12.40/lib/fluent/plugin/in_tail.rb:295:in `run'
```

I've renamed `log` variable to `value` :)