### PR TITLE
emit transaction failed: error_class=NoMethodError error=undefined method dump

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -343,7 +343,6 @@ module Fluent
 
       es.each { |time, record|
         record = merge_json_log(record) if @merge_json_log
-
         metadata = nil
         if record.has_key?('CONTAINER_NAME') && record.has_key?('CONTAINER_ID_FULL')
           metadata = record['CONTAINER_NAME'].match(@container_name_to_kubernetes_regexp_compiled) do |match_data|
@@ -362,11 +361,11 @@ module Fluent
           end
           unless metadata
             log.debug "Error: could not match CONTAINER_NAME from record #{record}"
-            @stats.dump(:container_name_match_failed)
+            @stats.bump(:container_name_match_failed)
           end
         elsif record.has_key?('CONTAINER_NAME') && record['CONTAINER_NAME'].start_with?('k8s_')
           log.debug "Error: no container name and id in record #{record}"
-          @stats.dump(:container_name_id_missing)
+          @stats.bump(:container_name_id_missing)
         end
 
         if metadata


### PR DESCRIPTION
Was getting this error:
2017-12-01 19:39:32 +0000 [warn]: emit transaction failed: error_class=NoMethodError error="undefined method `dump' for #<KubernetesMetadata::Stats:0x000000024b7ce0>\nDid you mean?  dup" tag="kubernetes.var.log.containers.mux-mux.mux-mux_testproj_mux-0123456789012345678901234567890123456789012345678901234567890123.log.mux"

Method should be `bump` instead of `dump`.  I also added some tests
for these lines of code.
@jcantrill