### PR TITLE
preserve nested log field through merge

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -395,9 +395,13 @@ module Fluent
         value = record[@merge_json_log_key].strip
         if value[0].eql?('{') && value[-1].eql?('}')
           begin
-            record = JSON.parse(value).merge(record)
+            unpacked = JSON.parse(value)
+            record = unpacked.merge(record)
             unless @preserve_json_log
               record.delete(@merge_json_log_key)
+              if unpacked.has_key?(@merge_json_log_key)
+                record[@merge_json_log_key] = unpacked[@merge_json_log_key]
+              end
             end
           rescue JSON::ParserError=>e
             @stats.bump(:merge_json_parse_errors)

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -154,7 +154,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
           include_namespace_metadata true
         ', d: nil)
       d = create_driver(config) if d.nil?
-      if ENV['LOGLEVEL'] 
+      if ENV['LOGLEVEL']
         logger = Logger.new(STDOUT)
         logger.level = eval("Logger::#{ENV['LOGLEVEL'].upcase}")
         instance = d.instance
@@ -205,7 +205,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
           }
         }
-        
+
         assert_equal(expected_kube_metadata, es.instance_variable_get(:@record_array)[0])
       end
     end
@@ -242,7 +242,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             }
           }
         }
-        
+
         assert_equal(expected_kube_metadata, es.instance_variable_get(:@record_array)[0])
       end
     end
@@ -268,7 +268,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             }
           }
         }
-        
+
         assert_equal(expected_kube_metadata, es.instance_variable_get(:@record_array)[0])
       end
     end
@@ -485,6 +485,19 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
 preserve_json_log false
 use_journal true
 ')
+      assert_equal(json_log, es.instance_variable_get(:@record_array)[0])
+    end
+
+    test 'emit individual fields from json, throw out whole original string, keep inner field' do
+      json_log = {
+        'hello' => 'world',
+        'more' => 'data',
+        'log' => 'keep me'
+      }
+      msg = {
+        'log' => "#{json_log.to_json}"
+      }
+      es = emit_with_tag('non-kubernetes', msg, 'preserve_json_log false')
       assert_equal(json_log, es.instance_variable_get(:@record_array)[0])
     end
 


### PR DESCRIPTION
This fixes an issue when you have a valid log field with the same name within your json log that is being merged. For example if the merge_json_log_key is "log" and you have a json blob as follows: 
```
{"something": "blah", "log": "I want to preserve this"}
```
then that inner "I want to preserve this" message will be dropped when preserve_json_log  is set. This is not good as the purpose of that flag is whether or not to preserve the outer json, not to eliminate the inner field. This PR properly preserves that inner field after the merge.
  