### PR TITLE
Implement kubernetes.container_image

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -262,17 +262,25 @@ module Fluent::Plugin
 
     end
 
-    def get_metadata_for_record(match_data, cache_key, create_time, batch_miss_cache)
+    def get_metadata_for_record(match_data, container_id, create_time, batch_miss_cache)
       namespace_name = match_data['namespace']
       pod_name = match_data['pod_name']
+      container_name = match_data['container_name']
       metadata = {
-        'container_name' => match_data['container_name'],
-        'namespace_name' => namespace_name,
-        'pod_name'       => pod_name
+        'container_name'  => container_name,
+        'namespace_name'  => namespace_name,
+        'pod_name'        => pod_name
       }
       if @kubernetes_url.present?
-        pod_metadata = get_pod_metadata(cache_key, namespace_name, pod_name, create_time, batch_miss_cache)
+        pod_metadata = get_pod_metadata(container_id, namespace_name, pod_name, create_time, batch_miss_cache)
+
+        if (pod_metadata.include? 'containers') && (pod_metadata['containers'].include? container_id)
+          metadata['container_image'] = pod_metadata['containers'][container_id]['image']
+          metadata['container_image_id'] = pod_metadata['containers'][container_id]['image_id']
+        end
+
         metadata.merge!(pod_metadata) if pod_metadata
+        metadata.delete('containers')
       end
       metadata
     end

--- a/lib/fluent/plugin/kubernetes_metadata_cache_strategy.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_cache_strategy.rb
@@ -83,6 +83,7 @@ module KubernetesMetadata
         end
         @id_cache[key] = ids unless batch_miss_cache.key?("#{namespace_name}_#{pod_name}")
       end
+
       # remove namespace info that is only used for comparison
       metadata.delete('creation_timestamp')
       metadata.delete_if{|k,v| v.nil?}

--- a/test/cassettes/kubernetes_docker_metadata_using_bearer_token.yml
+++ b/test/cassettes/kubernetes_docker_metadata_using_bearer_token.yml
@@ -174,7 +174,7 @@ http_interactions:
                 "restartCount": 2,
                 "image": "fabric8/hawtio-kubernetes:latest",
                 "imageID": "docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303",
-                "containerID": "docker://1b1d1f61c1205fe73328c75b2945e2ce05acfba2fde16299a8103fb22e9ec58a"
+                "containerID": "docker://49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459"
               },
               {
                 "name": "POD",

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -206,11 +206,11 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'pod_name'       => 'fabric8-console-controller-98rqc',
-            'container_name' => 'fabric8-console-container',
-            'namespace_name' => 'default',
-            'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_name'        => 'fabric8-console-controller-98rqc',
+            'container_name'  => 'fabric8-console-container',
+            'namespace_name'  => 'default',
+            'namespace_id'    => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'pod_id'          => 'c76927af-f563-11e4-b32d-54ee7527188d',
           }
         }
 
@@ -237,13 +237,15 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'host'           => 'jimmi-redhat.localnet',
-            'pod_name'       => 'fabric8-console-controller-98rqc',
-            'container_name' => 'fabric8-console-container',
-            'namespace_name' => 'default',
-            'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-            'master_url'     => 'https://localhost:8443',
+            'host'               => 'jimmi-redhat.localnet',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_name'     => 'default',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'         => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -263,13 +265,15 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'host'           => 'jimmi-redhat.localnet',
-            'pod_name'       => 'fabric8-console-controller-98rqc',
-            'container_name' => 'fabric8-console-container',
-            'namespace_name' => 'default',
-            'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-            'master_url'     => 'https://localhost:8443',
+            'host'               => 'jimmi-redhat.localnet',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_name'     => 'default',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'         => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -292,13 +296,15 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'host'           => 'jimmi-redhat.localnet',
-            'pod_name'       => 'fabric8-console-controller-98rqc',
-            'container_name' => 'fabric8-console-container',
-            'namespace_name' => 'default',
-            'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-            'master_url'     => 'https://localhost:8443',
+            'host'               => 'jimmi-redhat.localnet',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_name'     => 'default',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'         => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -321,13 +327,15 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'host'           => 'jimmi-redhat.localnet',
-            'pod_name'       => 'fabric8-console-controller-98rqc',
-            'container_name' => 'fabric8-console-container',
-            'namespace_name' => 'default',
-            'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-            'master_url'     => 'https://localhost:8443',
+            'host'               => 'jimmi-redhat.localnet',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_name'     => 'default',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'         => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -344,9 +352,9 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-              'pod_name'       => 'fabric8-console-controller-98rqc',
-              'container_name' => 'fabric8-console-container',
-              'namespace_name' => 'default',
+              'pod_name'        => 'fabric8-console-controller-98rqc',
+              'container_name'  => 'fabric8-console-container',
+              'namespace_name'  => 'default',
           }
       }
       assert_equal(expected_kube_metadata, filtered[0])
@@ -366,11 +374,11 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
           'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
         },
         'kubernetes' => {
-          'pod_name'       => 'fabric8-console-controller-98rqc',
-          'container_name' => 'fabric8-console-container',
-          'namespace_name' => '.orphaned',
+          'pod_name'           => 'fabric8-console-controller-98rqc',
+          'container_name'     => 'fabric8-console-container',
+          'namespace_name'     => '.orphaned',
           'orphaned_namespace' => 'default',
-          'namespace_id' => 'orphaned'
+          'namespace_id'       => 'orphaned'
         }
       }
       assert_equal(expected_kube_metadata, filtered[0])
@@ -389,9 +397,9 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
           'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
         },
         'kubernetes' => {
-          'pod_name'       => 'fabric8-console-controller.98rqc',
-          'container_name' => 'fabric8-console-container',
-          'namespace_name' => 'default'
+          'pod_name'        => 'fabric8-console-controller.98rqc',
+          'container_name'  => 'fabric8-console-container',
+          'namespace_name'  => 'default'
         }
       }
       assert_equal(expected_kube_metadata, filtered[0])
@@ -423,16 +431,18 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'host'             => 'jimmi-redhat.localnet',
-            'pod_name'         => 'fabric8-console-controller-98rqc',
-            'container_name'   => 'fabric8-console-container',
-            'namespace_id'     => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'namespace_labels' => {
+            'host'               => 'jimmi-redhat.localnet',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'namespace_labels'   => {
               'kubernetes_io/namespacetest' => 'somevalue'
             },
-            'namespace_name'   => 'default',
-            'pod_id'           => 'c76927af-f563-11e4-b32d-54ee7527188d',
-            'master_url'       => 'https://localhost:8443',
+            'namespace_name'     => 'default',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'         => 'https://localhost:8443',
             'labels' => {
               'kubernetes_io/test' => 'somevalue'
             }
@@ -455,16 +465,18 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'host'             => 'jimmi-redhat.localnet',
-            'pod_name'         => 'fabric8-console-controller-98rqc',
-            'container_name'   => 'fabric8-console-container',
-            'namespace_id'     => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'namespace_labels' => {
+            'host'               => 'jimmi-redhat.localnet',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'namespace_labels'   => {
               'kubernetes.io/namespacetest' => 'somevalue'
             },
-            'namespace_name'   => 'default',
-            'pod_id'           => 'c76927af-f563-11e4-b32d-54ee7527188d',
-            'master_url'       => 'https://localhost:8443',
+            'namespace_name'     => 'default',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'         => 'https://localhost:8443',
             'labels' => {
               'kubernetes.io/test' => 'somevalue'
             }
@@ -502,13 +514,15 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'host'           => 'jimmi-redhat.localnet',
-            'pod_name'       => 'fabric8-console-controller-98rqc',
-            'container_name' => 'fabric8-console-container',
-            'namespace_name' => 'default',
-            'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-            'master_url'     => 'https://localhost:8443',
+            'host'               => 'jimmi-redhat.localnet',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_name'     => 'default',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'         => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -538,13 +552,15 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'host'           => 'jimmi-redhat.localnet',
-            'pod_name'       => 'fabric8-console-controller-98rqc',
-            'container_name' => 'fabric8-console-container',
-            'namespace_name' => 'default',
-            'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-            'master_url'     => 'https://localhost:8443',
+            'host'               => 'jimmi-redhat.localnet',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_name'     => 'default',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'         => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -567,14 +583,16 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
                 'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
             },
             'kubernetes' => {
-                'host'           => 'jimmi-redhat.localnet',
-                'pod_name'       => 'fabric8-console-controller-98rqc',
-                'container_name' => 'fabric8-console-container',
-                'namespace_name' => 'default',
-                'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-                'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-                'master_url'     => 'https://localhost:8443',
-                'labels'         => {
+                'host'               => 'jimmi-redhat.localnet',
+                'pod_name'           => 'fabric8-console-controller-98rqc',
+                'container_name'     => 'fabric8-console-container',
+                'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+                'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+                'namespace_name'     => 'default',
+                'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+                'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+                'master_url'         => 'https://localhost:8443',
+                'labels'             => {
                     'component' => 'fabric8Console'
                 },
                 'annotations'    => {
@@ -607,13 +625,15 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
           },
           'kubernetes' => {
-            'host'           => 'jimmi-redhat.localnet',
-            'pod_name'       => 'fabric8-console-controller-98rqc',
-            'container_name' => 'fabric8-console-container',
-            'namespace_name' => 'default',
-            'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-            'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-            'master_url'     => 'https://localhost:8443',
+            'host'               => 'jimmi-redhat.localnet',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_name'     => 'default',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'master_url'         => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
             }
@@ -636,14 +656,16 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
                 'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
             },
             'kubernetes' => {
-                'host'           => 'jimmi-redhat.localnet',
-                'pod_name'       => 'fabric8-console-controller-98rqc',
-                'container_name' => 'fabric8-console-container',
-                'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-                'namespace_name' => 'default',
-                'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-                'master_url'     => 'https://localhost:8443',
-                'labels'         => {
+                'host'               => 'jimmi-redhat.localnet',
+                'pod_name'           => 'fabric8-console-controller-98rqc',
+                'container_name'     => 'fabric8-console-container',
+                'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+                'namespace_name'     => 'default',
+                'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+                'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+                'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+                'master_url'         => 'https://localhost:8443',
+                'labels'             => {
                     'component' => 'fabric8Console'
                 },
                 'annotations'    => {
@@ -672,14 +694,16 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
                 'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
             },
             'kubernetes' => {
-                'host'           => 'jimmi-redhat.localnet',
-                'pod_name'       => 'fabric8-console-controller-98rqc',
-                'container_name' => 'fabric8-console-container',
-                'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
-                'namespace_name' => 'default',
-                'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
-                'master_url'     => 'https://localhost:8443',
-                'labels'         => {
+                'host'               => 'jimmi-redhat.localnet',
+                'pod_name'           => 'fabric8-console-controller-98rqc',
+                'container_name'     => 'fabric8-console-container',
+                'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+                'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+                'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+                'namespace_name'     => 'default',
+                'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+                'master_url'         => 'https://localhost:8443',
+                'labels'             => {
                     'component' => 'fabric8Console'
                 }
             }

--- a/test/plugin/test_watch_pods.rb
+++ b/test/plugin/test_watch_pods.rb
@@ -35,7 +35,14 @@ class DefaultPodWatchStrategyTest < WatchTest
                 'labels' => {},
             },
             'spec' => {
-                'nodeName' => 'aNodeName'
+                'nodeName' => 'aNodeName',
+                'containers' => [{
+                     'name' => 'foo',
+                     'image' => 'bar',
+                 }, {
+                     'name' => 'bar',
+                     'image' => 'foo',
+                 }]
             }
          }
        )
@@ -49,8 +56,33 @@ class DefaultPodWatchStrategyTest < WatchTest
                 'labels' => {},
             },
             'spec' => {
-                'nodeName' => 'aNodeName'
-            }
+                'nodeName' => 'aNodeName',
+                'containers' => [{
+                    'name' => 'foo',
+                    'image' => 'bar',
+                 }, {
+                    'name' => 'bar',
+                    'image' => 'foo',
+                 }]
+            },
+           'status' => {
+               'containerStatuses' => [
+                   {
+                       'name' => 'fabric8-console-container',
+                       'state' => {
+                           'running' => {
+                               'startedAt' => '2015-05-08T09:22:44Z'
+                           }
+                       },
+                       'lastState' => {},
+                       'ready' => true,
+                       'restartCount' => 0,
+                       'image' => 'fabric8/hawtio-kubernetes:latest',
+                       'imageID' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+                       'containerID' => 'docker://49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
+                   }
+               ]
+           }
          }
        )
        @deleted = OpenStruct.new(


### PR DESCRIPTION
Implementing adding of `kubernetes.container_image` and `kubernetes.container_image_id` from `status.containerStatuses` information as requested in #54

There are no additional api calls and this change is using the existing caching.

First version: get info from pod spec (can cause caching issues)
Second version: get from containerStatuses (prevents possible caching issues, better to display unknown docker image instead of possible wrong docker image)

Available as docker image: `mblaschke/fluentd`
