### PR TITLE
Remove references to include_namespace_metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ This must used named capture groups for `container_name`, `pod_name` & `namespac
 * `use_journal` - If false (default), messages are expected to be formatted and tagged as if read by the fluentd in\_tail plugin with wildcard filename.  If true, messages are expected to be formatted as if read from the systemd journal.  The `MESSAGE` field has the full message.  The `CONTAINER_NAME` field has the encoded k8s metadata (see below).  The `CONTAINER_ID_FULL` field has the full container uuid.  This requires docker to use the `--log-driver=journald` log driver.
 * `container_name_to_kubernetes_regexp` - The regular expression used to extract the k8s metadata encoded in the journal `CONTAINER_NAME` field (default: `'^(?<name_prefix>[^_]+)_(?<container_name>[^\._]+)(\.(?<container_hash>[^_]+))?_(?<pod_name>[^_]+)_(?<namespace>[^_]+)_[^_]+_[^_]+$'`
   * This corresponds to the definition [in the source](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockertools/docker.go#L317)
-* `include_namespace_metadata` - Collect metadata about namespace such as uid, labels and annotations (default: `false`).  
-  Note that when this option is enabled, all label from namespace are collected, but annotations are collected according to `annotation_match` value. If `annotation_match` is not presented, no annotations will be collected from the namespace.
 * `annotation_match` - Array of regular expressions matching annotation field names. Matched annotations are added to a log record.
 * `allow_orphans` - Modify the namespace and namespace id to the values of `orphaned_namespace_name` and `orphaned_namespace_id`
 when true (default: `true`)

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -34,22 +34,6 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
     Test::FilterTestDriver.new(KubernetesMetadataFilter, 'var.log.containers.fabric8-console-controller-98rqc_default_fabric8-console-container-49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459.log').configure(conf, true)
   end
 
-  sub_test_case 'dump_stats' do
-
-    test 'dump stats with include_namespace_metadata' do
-      VCR.use_cassette('kubernetes_docker_metadata') do
-        d = create_driver('
-          kubernetes_url https://localhost:8443
-          watch false
-          cache_size 1
-          include_namespace_metadata false
-          stats_interval 0
-        ')
-        d.instance.dump_stats
-      end
-    end
-
-  end
   sub_test_case 'configure' do
     test 'check default' do
       d = create_driver
@@ -151,7 +135,6 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
           kubernetes_url https://localhost:8443
           watch false
           cache_size 1
-          include_namespace_metadata true
         ', d: nil)
       d = create_driver(config) if d.nil?
       if ENV['LOGLEVEL'] 
@@ -182,7 +165,6 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
           kubernetes_url https://localhost:8443
           watch false
           cache_size 1
-          include_namespace_metadata true
         ')
         cache = driver.instance.instance_variable_get(:@id_cache)
         cache['49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'] = {
@@ -216,7 +198,6 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
           kubernetes_url https://localhost:8443
           watch false
           cache_size 1
-          include_namespace_metadata true
         ')
         cache = driver.instance.instance_variable_get(:@id_cache)
         cache['49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'] = {
@@ -279,7 +260,6 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
           kubernetes_url https://localhost:8443
           watch false
           cache_size 1
-          include_namespace_id true
         ')
         expected_kube_metadata = {
           'docker' => {
@@ -494,7 +474,6 @@ use_journal true
           kubernetes_url https://localhost:8443
           watch false
           cache_size 1
-          include_namespace_metadata true
         ')
         expected_kube_metadata = {
           'docker' => {
@@ -527,7 +506,6 @@ use_journal true
           watch false
           cache_size 1
           de_dot false
-          include_namespace_metadata true
         ')
         expected_kube_metadata = {
           'docker' => {
@@ -610,7 +588,6 @@ use_journal true
           kubernetes_url https://localhost:8443
           watch false
           cache_size 1
-          include_namespace_id true
           use_journal true
         ')
         expected_kube_metadata = {
@@ -709,7 +686,6 @@ use_journal true
           kubernetes_url https://localhost:8443
           watch false
           cache_size 1
-          include_namespace_metadata true
           annotation_match [ "^custom.+", "two", "workspace*"]
         ')
         expected_kube_metadata = {
@@ -746,7 +722,6 @@ use_journal true
           kubernetes_url https://localhost:8443
           watch false
           cache_size 1
-          include_namespace_metadata true
           annotation_match [ "noMatch*"]
         ')
         expected_kube_metadata = {


### PR DESCRIPTION
include_namespace_metadata and include_namespace_id have been removed
from the code and so using them triggers a warning in fluent. We should
remove them from docs and tests so that they aren't used by accident.

Closes: #113