### PR TITLE
Add _jsonparsefailure to tags field if merge_json_log fails

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -358,6 +358,11 @@ module Fluent
             end
           rescue JSON::ParserError=>e
             @stats.bump(:merge_json_parse_errors)
+            if record.has_key?('tags') and record['tags'].is_a? Array
+              record['tags'].push(' _jsonparsefailure')
+            else
+              record['tags']=['_jsonparsefailure']
+            end
             log.debug(e)
           end
         end


### PR DESCRIPTION
Add "_jsonparsefailure" to tags array if the logmessage starts with "{" and JSON.parse() fails. This is similar to what logstash does.