### PR TITLE
do not process empty es to avoid stack trace

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -284,6 +284,7 @@ module Fluent
     end
 
     def filter_stream_from_files(tag, es)
+      return es if es.empty?
       new_es = MultiEventStream.new
 
       match_data = tag.match(@tag_to_kubernetes_name_regexp_compiled)


### PR DESCRIPTION
fixes #116 by checking if the event stream is empty before continuing to process...