### PR TITLE
Turn off JSON payload merges by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ This must used named capture groups for `container_name`, `pod_name` & `namespac
 * `cache_size` - size of the cache of Kubernetes metadata to reduce requests to the API server (default: `1000`)
 * `cache_ttl` - TTL in seconds of each cached element. Set to negative value to disable TTL eviction (default: `3600` - 1 hour)
 * `watch` - set up a watch on pods on the API server for updates to metadata (default: `true`)
-* `merge_json_log` - merge logs in JSON format as top level keys (default: `true`)
-* `preserve_json_log` - preserve JSON logs in raw form in the `log` key, only used if the previous option is true (default: `true`)
+* `merge_json_log` - merge logs in JSON format as top level keys (default: `true`, DEPRECATED)
+  * WARNING: The configuration option, `merge_json_log` is deprecated and will be removed in a future release; please use fluent's [`filter_parser`](https://docs.fluentd.org/v0.12/articles/filter_parser) instead to parse arbitrary log message payloads as JSON strings
+* `preserve_json_log` - preserve JSON logs in raw form in the `log` key, only used if the previous option is true (default: `true`, DEPRECATED)
+  * WARNING: The configuration option, `preserve_json_log` is deprecated and will be removed in a future release; please use fluent's [`filter_parser`](https://docs.fluentd.org/v0.12/articles/filter_parser) instead to parse arbitrary log message payloads as JSON strings
 * `de_dot` - replace dots in labels and annotations with configured `de_dot_separator`, required for ElasticSearch 2.x compatibility (default: `true`)
 * `de_dot_separator` - separator to use if `de_dot` is enabled (default: `_`)
 * `use_journal` - If false (default), messages are expected to be formatted and tagged as if read by the fluentd in\_tail plugin with wildcard filename.  If true, messages are expected to be formatted as if read from the systemd journal.  The `MESSAGE` field has the full message.  The `CONTAINER_NAME` field has the encoded k8s metadata (see below).  The `CONTAINER_ID_FULL` field has the full container uuid.  This requires docker to use the `--log-driver=journald` log driver.

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -50,7 +50,7 @@ module Fluent::Plugin
                  :string,
                  :default => 'var\.log\.containers\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
     config_param :bearer_token_file, :string, default: nil
-    config_param :merge_json_log, :bool, default: true
+    config_param :merge_json_log, :bool, default: false
     config_param :preserve_json_log, :bool, default: true
     config_param :secret_dir, :string, default: '/var/run/secrets/kubernetes.io/serviceaccount'
     config_param :de_dot, :bool, default: true


### PR DESCRIPTION
Merging JSON payloads into the log metadata by default is not a good
idea because of the potential negative impact it can have on the fields
for Elasticsearch.

For example, imagine each log line emitted by a container looks like
the following:
```
{ "abca072a2mwqpc78": 0 }
```
Where the key is "`abca072a2mwqpc78`" and its value is "`0`".

If the container generates a random value for that key, or perhaps a
number in a monotonically increasing sequence, thousands of fields can
be generated for the combined set of JSON documents indexed into
Elasticsearch.  Without an additional filter that could detect such bad
behaviors, and compare against the existing mapping of a target index,
this can cause major problems for Elasticsearch.  Each new field added
to a mapping in Elasticsearch causes a cluster state transition, which
are very very slow (on the order of seconds), and an commensurate
increase in memory usage to track those fields (which can cause
Elasticsearch to exhaust its HEAP, or at least engage in heavy garbage
collection processing).

Use of this option should only be done if the user knows well what they
are doing.

Additionally, with this commit we are deprecated the use of the option,
and will be removing the option and its functionality in a future
release.  Please consider the use of the fluentd `filter_parser` [1]
instead.

[1] https://docs.fluentd.org/v0.12/articles/filter_parser