### PR TITLE
Uses an optional environment variable to avoid needless cache misses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ Reading from the systemd journal (requires the fluentd `fluent-plugin-systemd` a
 </match>
 ```
 
+## Environment variables for Kubernetes
+
+If the name of the Kubernetes node the plugin is running on is set as
+an environment variable with the name `K8S_NODE_NAME`, it will reduce cache
+misses and needless calls to the Kubernetes API.
+
+In the Kubernetes container definition, this is easily accomplished by:
+
+```yaml
+env:
+- name: K8S_NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+```
+
 ## Example input/output
 
 Kubernetes creates symlinks to Docker log files in `/var/log/containers/*.log`. Docker logs in JSON format.

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -42,6 +42,9 @@ module KubernetesMetadata
             if cached
               @cache[cache_key] = parse_pod_metadata(notice.object)
               @stats.bump(:pod_cache_watch_updates)
+            elsif ENV['K8S_NODE_NAME'] == notice.object['spec']['nodeName'] then
+              @cache[cache_key] = parse_pod_metadata(notice.object)
+              @stats.bump(:pod_cache_host_updates)
             else
               @stats.bump(:pod_cache_watch_misses)
             end

--- a/test/plugin/test_watch_pods.rb
+++ b/test/plugin/test_watch_pods.rb
@@ -81,6 +81,17 @@ class DefaultPodWatchStrategyTest < WatchTest
       end
     end
 
+    test 'pod MODIFIED cached when hostname matches' do
+      orig_env_val = ENV['K8S_NODE_NAME']
+      ENV['K8S_NODE_NAME'] = 'aNodeName'
+      @client.stub :watch_pods, [@modified] do
+       start_pod_watch
+       assert_equal(true, @cache.key?('modified_uid'))
+       assert_equal(1, @stats[:pod_cache_host_updates])
+      end
+      ENV['K8S_NODE_NAME'] = orig_env_val
+    end
+
     test 'pod watch notice is updated when MODIFIED is received' do
       @cache['modified_uid'] = {}
       @client.stub :watch_pods, [@modified] do


### PR DESCRIPTION
I have a k8s cluster that handles a large numbers of Kubernetes Jobs. Normally, these take a while, but sometimes the job starts and stops almost immediately, at which point it is removed from the cluster. When this occurs, the logs are still harvested, but when `get_pod_metadata` hits the k8s API, the pod it's looking for no longer exists. As a result, most of the metadata is missing.

The plugin has already gotten the metadata for the pod as part of the watcher, but discarded it since nothing had asked for it yet - all it did was bump `:pod_cache_watch_misses`.

To solve this problem, I added an environment variable called `K8S_NODE_NAME` (easily auto-populated by k8s) that contains the name of the kubernetes node.  Whenever a watch event arrives, before discarding it because the ID is not currently in the cache, it checks to see if the nodeName on the pod matches the node name in the environment variable.  Assuming it matches, it goes ahead and adds the pod metadata to the cache.

This has several a couple advantages:
1. Fixes issue #123, where short-lived pods don't get queried until they no longer exist.
2. It avoids calling the kubernetes pod API to request data that the watcher already had and discarded.

I wasn't super happy with adding environment variables into the mix, but I couldn't come up with a cleaner way.  If anyone has a better idea, I'm happy to discuss it.