### PR TITLE
Add the functionality to enrich the record with metadata of a specific pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ This must used named capture groups for `container_name`, `pod_name` & `namespac
 when true (default: `true`)
 * `orphaned_namespace_name` - The namespace to associate with records where the namespace can not be determined (default: `.orphaned`)
 * `orphaned_namespace_id` - The namespace id to associate with records where the namespace can not be determined (default: `orphaned`)
+* `<metadata_source> section` - The names of the kubernetes resource as the source of metadata. You can only specify one kubernetes resource here. This is useful if the fluentd is running as a sidecar, where you only want to enrich the metadata of the pod that the sidecar is running in. You can easily pass the the namespace_name and the pod_name from the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/).
+  * `namespace_name` - The name of the namespace. This is required if `<metadata_source>` is specified.
+  * `pod_name` - The name of the pod. This is required if `<metadata_source>` is specified.
+  * `container_name` - The name of the container. Metadata of the container will be added if `container_name` is specified (default: `nil`)
 
 **NOTE:** As of the release 2.1.x of this plugin, it no longer supports parsing the source message into JSON and attaching it to the
 payload.  The following configuration options are removed:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ This must used named capture groups for `container_name`, `pod_name` & `namespac
 when true (default: `true`)
 * `orphaned_namespace_name` - The namespace to associate with records where the namespace can not be determined (default: `.orphaned`)
 * `orphaned_namespace_id` - The namespace id to associate with records where the namespace can not be determined (default: `orphaned`)
-* `<metadata_source> section` - The names of the kubernetes resource as the source of metadata. You can only specify one kubernetes resource here. This is useful if the fluentd is running as a sidecar, where you only want to enrich the metadata of the pod that the sidecar is running in. You can easily pass the the namespace_name and the pod_name from the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/).
+* `<metadata_source> section` - The names of the kubernetes resource as the source of metadata. You can only specify one kubernetes resource here. This is useful if the fluentd is running as a sidecar, where you only want to enrich the metadata of the pod that the sidecar is running in.  
+You can easily set the the namespace_name and the pod_name through the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/) as environment variables, and use the [environment varialbes](https://docs.fluentd.org/v1.0/articles/faq#how-can-i-use-environment-variables-to-configure-parameters-dynamically?) to configure the plugin dynamically.
   * `namespace_name` - The name of the namespace. This is required if `<metadata_source>` is specified.
   * `pod_name` - The name of the pod. This is required if `<metadata_source>` is specified.
   * `container_name` - The name of the container. Metadata of the container will be added if `container_name` is specified (default: `nil`)

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -259,7 +259,7 @@ module Fluent::Plugin
       end
 
       if @metadata_source
-        log.debug "Will stream given metadata source #{metadata_source}"
+        log.on_debug { log.debug "Will stream given metadata source #{metadata_source}" }
         self.class.class_eval { alias_method :filter_stream, :filter_stream_given_metadata_source }
       elsif @use_journal
         log.debug "Will stream from the journal"
@@ -315,12 +315,12 @@ module Fluent::Plugin
       if @kubernetes_url.present?
         if @pod_metadata.nil?
           @pod_metadata = fetch_pod_metadata(namespace_name, pod_name)
-          log.info "Failed to fetch metadata of pod '#{pod_name}' given metadata source: #{metadata_source}" if @pod_metadata.empty?
+          log.on_info { log.info "Failed to fetch metadata of pod '#{pod_name}' given metadata source: #{metadata_source}" } if @pod_metadata.empty?
         end
 
         if @namespace_metadata.nil?
           @namespace_metadata = fetch_namespace_metadata(namespace_name)
-          log.info "Failed to fetch metadata of namespace '#{namespace_name}' given metadata source: #{metadata_source}" if @namespace_metadata.empty?
+          log.on_info { "Failed to fetch metadata of namespace '#{namespace_name}' given metadata source: #{metadata_source}" } if @namespace_metadata.empty?
         end
 
         kubernetes_metadata.merge!(@pod_metadata)

--- a/lib/fluent/plugin/kubernetes_metadata_watch_namespace.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_namespace.rb
@@ -1,0 +1,49 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'kubernetes_metadata_common'
+
+module KubernetesMetadata
+  module WatchNamespace
+
+    include ::KubernetesMetadata::Common
+
+    def start_namespace_watch
+      begin
+        watcher = @client.watch_namespaces({:name => @metadata_source.namespace_name})
+      rescue Exception => e
+        message = "start_namespace_watch: Exception encountered setting up namespace watch from Kubernetes API #{@apiVersion} endpoint #{@kubernetes_url}: #{e.message}"
+        message += " (#{e.response})" if e.respond_to?(:response)
+        raise Fluent::ConfigError, message
+      end
+
+      watcher.each do |notice|
+        case notice.type
+          when 'MODIFIED', 'ADDED'
+            @namespace_metadata = parse_namespace_metadata(notice.object)
+            @stats.bump(:namespace_cache_watch_updates)
+          else
+            # ignore and let age out for cases where 
+            # deleted but still processing logs
+            @stats.bump(:namespace_cache_watch_ignored)
+        end
+      end
+    end
+
+  end
+end

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pod.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pod.rb
@@ -1,0 +1,48 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'kubernetes_metadata_common'
+
+module KubernetesMetadata
+  module WatchPod
+
+    include ::KubernetesMetadata::Common
+
+    def start_pod_watch
+      begin
+        watcher = @client.watch_pods({:namespace => @metadata_source.namespace_name, :name => @metadata_source.pod_name})
+      rescue Exception => e
+        message = "Exception encountered fetching metadata from Kubernetes API endpoint: #{e.message}"
+        message += " (#{e.response})" if e.respond_to?(:response)
+        raise Fluent::ConfigError, message
+      end
+
+      watcher.each do |notice|
+        case notice.type
+          when 'MODIFIED', 'ADDED'
+            @pod_metadata = parse_pod_metadata(notice.object)
+            @stats.bump(:pod_cache_watch_updates)
+          else
+            # ignore and let age out for cases where 
+            # deleted but still processing logs
+            @stats.bump(:pod_cache_watch_ignored)
+        end
+      end
+    end
+  end
+end

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -158,22 +158,37 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
       d.filtered.map{|e| e.last}
     end
 
-    test 'nil event stream from journal' do
-     #not certain how this is possible but adding test to properly
-     #guard against this condition we have seen
+    test 'nil event stream given metadata source' do
+      #not certain how this is possible but adding test to properly
+      #guard against this condition we have seen
+ 
+      plugin = create_driver('
+        <metadata_source>
+          namespace_name default
+          pod_name fabric8-console-controller-98rqc
+          container_name fabric8-console-container
+        </metadata_source>
+      ').instance
+      plugin.filter_stream_given_metadata_source('tag', nil)
+      plugin.filter_stream_given_metadata_source('tag', Fluent::MultiEventStream.new)
+    end
 
-     plugin = create_driver.instance
-     plugin.filter_stream_from_journal('tag', nil)
-     plugin.filter_stream_from_journal('tag', Fluent::MultiEventStream.new)
+    test 'nil event stream from journal' do
+      #not certain how this is possible but adding test to properly
+      #guard against this condition we have seen
+
+      plugin = create_driver.instance
+      plugin.filter_stream_from_journal('tag', nil)
+      plugin.filter_stream_from_journal('tag', Fluent::MultiEventStream.new)
     end
 
     test 'nil event stream from files' do
-     #not certain how this is possible but adding test to properly
-     #guard against this condition we have seen
+      #not certain how this is possible but adding test to properly
+      #guard against this condition we have seen
 
-     plugin = create_driver.instance
-     plugin.filter_stream_from_files('tag', nil)
-     plugin.filter_stream_from_files('tag', Fluent::MultiEventStream.new)
+      plugin = create_driver.instance
+      plugin.filter_stream_from_files('tag', nil)
+      plugin.filter_stream_from_files('tag', Fluent::MultiEventStream.new)
     end
 
     test 'inability to connect to the api server handles exception and doensnt block pipeline' do
@@ -770,6 +785,124 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
           'CONTAINER_ID_FULL' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459',
           'randomfield' => 'randomvalue'
         }
+        assert_equal(expected_kube_metadata, filtered[0])
+      end
+    end
+
+    test 'with given metadata source but kubernetes url does not exist' do
+      VCR.use_cassette('kubernetes_docker_metadata') do
+        filtered = emit_with_tag('random_tag', {'time'=>'2015-05-08T09:22:01Z'}, '
+          watch false
+          cache_size 1
+          <metadata_source>
+            namespace_name default
+            pod_name fabric8-console-controller-98rqc
+            container_name fabric8-console-container
+          </metadata_source>
+        ')
+
+        expected_kube_metadata = {
+          'time'=>'2015-05-08T09:22:01Z',
+          'kubernetes' => {
+            'namespace_name'     => 'default',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container'
+          }
+        }
+
+        assert_equal(expected_kube_metadata, filtered[0])
+      end
+    end
+
+    test 'with given metadata source and failed to fetch metadata' do
+      VCR.use_cassette('kubernetes_docker_metadata') do
+        stub_request(:any, 'https://localhost:8443/api/v1/namespaces/default/pods/fabric8-console-controller-98rqc').to_timeout
+        stub_request(:any, 'https://localhost:8443/api/v1/namespaces/default').to_timeout
+        filtered = emit_with_tag('random_tag', {'time'=>'2015-05-08T09:22:01Z'}, '
+          kubernetes_url https://localhost:8443
+          watch false
+          cache_size 1
+          <metadata_source>
+            namespace_name default
+            pod_name fabric8-console-controller-98rqc
+            container_name fabric8-console-container
+          </metadata_source>
+        ')
+
+        expected_kube_metadata = {
+          'time'=>'2015-05-08T09:22:01Z',
+          'kubernetes' => {
+            'namespace_name'     => 'default',
+            'pod_name'           => 'fabric8-console-controller-98rqc',
+            'container_name'     => 'fabric8-console-container'
+          }
+        }
+
+        assert_equal(expected_kube_metadata, filtered[0])
+      end
+    end
+
+    test 'with given metadata source and no container name specified' do
+      VCR.use_cassette('kubernetes_docker_metadata') do
+        filtered = emit_with_tag('random_tag', {'time'=>'2015-05-08T09:22:01Z'}, '
+          kubernetes_url https://localhost:8443
+          watch false
+          cache_size 1
+          <metadata_source>
+            namespace_name default
+            pod_name fabric8-console-controller-98rqc
+          </metadata_source>
+        ')
+
+        expected_kube_metadata = {
+          'time'=>'2015-05-08T09:22:01Z',
+          'kubernetes' => {
+            'host'           => 'jimmi-redhat.localnet',
+            'labels'         => {'component'=>'fabric8Console'},
+            'master_url'     => 'https://localhost:8443',
+            'namespace_id'   => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'namespace_name' => 'default',
+            'pod_id'         => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_name'       => 'fabric8-console-controller-98rqc'
+          }
+        }
+
+        assert_equal(expected_kube_metadata, filtered[0])
+      end
+    end
+
+    test 'with given metadata source and container name is specified' do
+      VCR.use_cassette('kubernetes_docker_metadata') do
+        filtered = emit_with_tag('random_tag', {'time'=>'2015-05-08T09:22:01Z'}, '
+          kubernetes_url https://localhost:8443
+          watch false
+          cache_size 1
+          <metadata_source>
+            namespace_name default
+            pod_name fabric8-console-controller-98rqc
+            container_name fabric8-console-container
+          </metadata_source>
+        ')
+
+        expected_kube_metadata = {
+          'time'=>'2015-05-08T09:22:01Z',
+          'docker' => {
+            'container_id' => "49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459"
+          },
+          'kubernetes' => {
+            'container_name'     => 'fabric8-console-container',
+            'container_image'    => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'host'               => 'jimmi-redhat.localnet',
+            'labels'             => {'component'=>'fabric8Console'},
+            'master_url'         => 'https://localhost:8443',
+            'namespace_id'       => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'namespace_name'     => 'default',
+            'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_name'           => 'fabric8-console-controller-98rqc'
+          }
+        }
+
         assert_equal(expected_kube_metadata, filtered[0])
       end
     end

--- a/test/plugin/test_watch_namespace.rb
+++ b/test/plugin/test_watch_namespace.rb
@@ -1,0 +1,84 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative '../helper'
+require 'ostruct'
+require_relative 'watch_test'
+
+class WatchNamespaceTestTest < WatchTest
+
+    include KubernetesMetadata::WatchNamespace
+
+    setup do
+      @added = OpenStruct.new(
+        type: 'ADDED',
+        object: {
+          'metadata' => {
+              'name' => 'added',
+              'uid' => 'added_uid'
+          }
+        }
+      )
+      @modified = OpenStruct.new(
+        type: 'MODIFIED',
+        object: {
+          'metadata' => {
+              'name' => 'foo',
+              'uid' => 'modified_uid'
+          }
+        }
+      )
+      @deleted = OpenStruct.new(
+        type: 'DELETED',
+        object: {
+          'metadata' => {
+              'name' => 'deleteme',
+              'uid' => 'deleted_uid'
+          }
+        }
+      )
+    end
+
+    test 'namespace watch updates cache when MODIFIED is received' do
+      @client.stub :watch_namespaces, [@modified] do
+       start_namespace_watch
+       assert_false @namespace_metadata.empty?
+       assert_equal('modified_uid', @namespace_metadata['namespace_id'])
+       assert_equal(1, @stats[:namespace_cache_watch_updates])
+      end
+    end
+
+    test 'namespace watch updates cache when ADDED is received' do
+      @client.stub :watch_namespaces, [@added] do
+       start_namespace_watch
+       assert_false @namespace_metadata.empty?
+       assert_equal('added_uid', @namespace_metadata['namespace_id'])
+       assert_equal(1, @stats[:namespace_cache_watch_updates])
+      end
+    end
+
+    test 'namespace watch ignores DELETED' do
+      @namespace_metadata = { 'namespace_id' => 'original_uid' }
+      @client.stub :watch_namespaces, [@deleted] do
+       start_namespace_watch
+       assert_equal('original_uid', @namespace_metadata['namespace_id'])
+       assert_equal(1, @stats[:namespace_cache_watch_ignored])
+      end
+    end
+
+end

--- a/test/plugin/test_watch_pod.rb
+++ b/test/plugin/test_watch_pod.rb
@@ -1,0 +1,126 @@
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative '../helper'
+require 'ostruct'
+require_relative 'watch_test'
+
+class WatchPodTestTest < WatchTest
+
+  include KubernetesMetadata::WatchPod
+
+  setup do
+    @added = OpenStruct.new(
+      type: 'ADDED',
+      object: {
+        'metadata' => {
+            'name' => 'added',
+            'namespace' => 'added',
+            'uid' => 'added_uid',
+            'labels' => {}
+        },
+        'spec' => {
+            'nodeName' => 'aNodeName',
+                'containers' => [{
+                'name' => 'foo',
+                'image' => 'bar'
+            }, {
+                'name' => 'bar',
+                'image' => 'foo'
+            }]
+        }
+      }
+    )
+    @modified = OpenStruct.new(
+      type: 'MODIFIED',
+      object: {
+        'metadata' => {
+            'name' => 'foo',
+            'namespace' => 'modified',
+            'uid' => 'modified_uid',
+            'labels' => {}
+        },
+        'spec' => {
+            'nodeName' => 'aNodeName',
+            'containers' => [{
+                'name' => 'foo',
+                'image' => 'bar'
+            }, {
+                'name' => 'bar',
+                'image' => 'foo'
+            }]
+        },
+        'status' => {
+            'containerStatuses' => [
+                {
+                    'name' => 'fabric8-console-container',
+                    'state' => {
+                        'running' => {
+                            'startedAt' => '2015-05-08T09:22:44Z'
+                        }
+                    },
+                    'lastState' => {},
+                    'ready' => true,
+                    'restartCount' => 0,
+                    'image' => 'fabric8/hawtio-kubernetes:latest',
+                    'imageID' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+                    'containerID' => 'docker://49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
+                }
+            ]
+        }
+      }
+    )
+    @deleted = OpenStruct.new(
+      type: 'DELETED',
+      object: {
+        'metadata' => {
+          'name' => 'deleteme',
+          'namespace' => 'deleted',
+          'uid' => 'deleted_uid'
+        }
+      }
+    )
+    end
+
+    test 'pod watch updates cache when MODIFIED is received' do
+      @client.stub :watch_pods, [@modified] do
+        start_pod_watch
+        assert_false @pod_metadata.empty?
+        assert_equal('modified_uid', @pod_metadata['pod_id'])
+        assert_equal(1, @stats[:pod_cache_watch_updates])
+      end
+    end
+
+    test 'pod watch updates cache when ADDED is received' do
+      @client.stub :watch_pods, [@added] do
+        start_pod_watch
+        assert_false @pod_metadata.empty?
+        assert_equal('added_uid', @pod_metadata['pod_id'])
+        assert_equal(1, @stats[:pod_cache_watch_updates])
+      end
+    end
+
+    test 'pod watch ignores DELETED' do
+      @pod_metadata = { 'pod_id' => 'original_uid' }
+      @client.stub :watch_pods, [@deleted] do
+       start_pod_watch
+       assert_equal('original_uid', @pod_metadata['pod_id'])
+       assert_equal(1, @stats[:pod_cache_watch_ignored])
+      end
+    end
+end

--- a/test/plugin/watch_test.rb
+++ b/test/plugin/watch_test.rb
@@ -27,6 +27,11 @@ class WatchTest < Test::Unit::TestCase
       @cache = {}
       @stats = KubernetesMetadata::Stats.new
       @client = OpenStruct.new
+      @metadata_source = OpenStruct.new(
+        'namespace_name' => 'default',
+        'pod_name' => 'pod_name',
+        'container_name' => 'container_name'
+      )
       def @client.resourceVersion
         '12345'
       end


### PR DESCRIPTION
I'd like to run fluentd as a sidecar instead of daemonset.
In this case, providing the config parameter of the desired pod will be much easier configuration wise, and also reduce the watch events that could incur.