### PR TITLE
do not process empty es to avoid stack trace

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -291,6 +291,7 @@ module Fluent::Plugin
     end
 
     def filter_stream_from_files(tag, es)
+      return es if es.nil? || es.empty?
       new_es = Fluent::MultiEventStream.new
 
       match_data = tag.match(@tag_to_kubernetes_name_regexp_compiled)
@@ -314,6 +315,7 @@ module Fluent::Plugin
     end
 
     def filter_stream_from_journal(tag, es)
+      return es if es.nil? || es.empty?
       new_es = Fluent::MultiEventStream.new
       batch_miss_cache = {}
       es.each do |time, record|

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -158,6 +158,24 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
       d.filtered.map{|e| e.last}
     end
 
+    test 'nil event stream from journal' do
+     #not certain how this is possible but adding test to properly
+     #guard against this condition we have seen
+
+     plugin = create_driver.instance
+     plugin.filter_stream_from_journal('tag', nil)
+     plugin.filter_stream_from_journal('tag', Fluent::MultiEventStream.new)
+    end
+
+    test 'nil event stream from files' do
+     #not certain how this is possible but adding test to properly
+     #guard against this condition we have seen
+
+     plugin = create_driver.instance
+     plugin.filter_stream_from_files('tag', nil)
+     plugin.filter_stream_from_files('tag', Fluent::MultiEventStream.new)
+    end
+
     test 'inability to connect to the api server handles exception and doensnt block pipeline' do
       VCR.use_cassette('kubernetes_docker_metadata') do
         driver = create_driver('


### PR DESCRIPTION
(cherry picked from commit 9b05ff18cfd648e84c1c689375b9bd6effe1e015)

fixes #134 