### PR TITLE
Why the output schema is different for master and v0.12 branch?

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -267,20 +267,23 @@ module Fluent::Plugin
       pod_name = match_data['pod_name']
       container_name = match_data['container_name']
       metadata = {
-        'container_name'  => container_name,
-        'namespace_name'  => namespace_name,
-        'pod_name'        => pod_name
+        'docker' => {'container_id' => container_id},
+        'kubernetes' => {
+          'container_name'  => container_name,
+          'namespace_name'  => namespace_name,
+          'pod_name'        => pod_name
+        }
       }
       if @kubernetes_url.present?
         pod_metadata = get_pod_metadata(container_id, namespace_name, pod_name, create_time, batch_miss_cache)
 
         if (pod_metadata.include? 'containers') && (pod_metadata['containers'].include? container_id)
-          metadata['container_image'] = pod_metadata['containers'][container_id]['image']
-          metadata['container_image_id'] = pod_metadata['containers'][container_id]['image_id']
+          metadata['kubernetes']['container_image'] = pod_metadata['containers'][container_id]['image']
+          metadata['kubernetes']['container_image_id'] = pod_metadata['containers'][container_id]['image_id']
         end
 
-        metadata.merge!(pod_metadata) if pod_metadata
-        metadata.delete('containers')
+        metadata['kubernetes'].merge!(pod_metadata) if pod_metadata
+        metadata['kubernetes'].delete('containers')
       end
       metadata
     end


### PR DESCRIPTION
@richm this can have quite a big impact on the community. Is [this change](https://github.com/richm/fluent-plugin-kubernetes_metadata_filter/commit/0c24bba138f6e972ca5488a6177cfa36fd20a13b#diff-83453022bdb83378e6c454e99caacd36R263) tailored to fit Viaq format or is that where we want to move for other reasons?

_Note_ that I didn't change tests files.