### PR TITLE
> fix time comparison error.

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -287,7 +287,8 @@ module Fluent::Plugin
       time_key = @time_fields.detect{ |ii| record.has_key?(ii) }
       time = record[time_key]
       if time.nil? || time.chop.empty?
-        return internal_time
+        # `internal_time` is a Fluent::EventTime, it can't compare with Time.
+        return Time.at(internal_time.to_f)
       end
       if ['_SOURCE_REALTIME_TIMESTAMP', '__REALTIME_TIMESTAMP'].include?(time_key)
         timei= time.to_i


### PR DESCRIPTION
Error trace:

```
2018-11-16 10:02:26 +0000 [warn]: #0 emit transaction failed: error_class=ArgumentError error="comparison of Time with Fluent::EventTime failed" location="/usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-kubernetes_metadata_filter-2.1.4/lib/fluent/plugin/kubernetes_metadata_cache_strategy.rb:53:in `<='" tag="kubernetes.var.log.containers.dce-fluentd-cgnb5_kube-system_dce-fluentd-232c0a5ec23d144be26933fe52043330f47fe8b4963520495891f21d1876552f.log"
  2018-11-16 10:02:26 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-kubernetes_metadata_filter-2.1.4/lib/fluent/plugin/kubernetes_metadata_cache_strategy.rb:53:in `<='
  2018-11-16 10:02:26 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-kubernetes_metadata_filter-2.1.4/lib/fluent/plugin/kubernetes_metadata_cache_strategy.rb:53:in `get_pod_metadata'
  2018-11-16 10:02:26 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-kubernetes_metadata_filter-2.1.4/lib/fluent/plugin/filter_kubernetes_metadata.rb:273:in `get_metadata_for_record'
  2018-11-16 10:02:26 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-kubernetes_metadata_filter-2.1.4/lib/fluent/plugin/filter_kubernetes_metadata.rb:307:in `block in filter_stream'
```

It because that internal_time is a Fluent::EventTime, but can't compare with Time.

EventTime Class: [https://github.com/fluent/fluentd/blob/master/lib/fluent/time.rb#L25](https://github.com/fluent/fluentd/blob/master/lib/fluent/time.rb#L25)

