### PR TITLE
Add brackets around IPv6 address when creating URL

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -22,8 +22,8 @@ require_relative 'kubernetes_metadata_common'
 require_relative 'kubernetes_metadata_stats'
 require_relative 'kubernetes_metadata_watch_namespaces'
 require_relative 'kubernetes_metadata_watch_pods'
-
 require 'fluent/plugin/filter'
+require 'resolv'
 
 module Fluent::Plugin
   class KubernetesMetadataFilter < Fluent::Plugin::Filter
@@ -192,6 +192,10 @@ module Fluent::Plugin
         env_host = ENV['KUBERNETES_SERVICE_HOST']
         env_port = ENV['KUBERNETES_SERVICE_PORT']
         if env_host.present? && env_port.present?
+          if env_host =~ Resolv::IPv6::Regex
+            # Brackets are needed around IPv6 addresses
+            env_host = "[#{env_host}]"
+          end
           @kubernetes_url = "https://#{env_host}:#{env_port}/api"
           log.debug "Kubernetes URL is now '#{@kubernetes_url}'"
         end


### PR DESCRIPTION
When the environment variable `KUBERNETES_SERVICE_HOST` is set to an IPv6 address, we need to add brackets around the address when constructing the URL.