### PR TITLE
Reduce metadata 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ when true (default: `true`)
 * `ssl_partial_chain` - if `ca_file` is for an intermediate CA, or otherwise we do not have the root CA and want
   to trust the intermediate CA certs we do have, set this to `true` - this corresponds to
   the `openssl s_client -partial_chain` flag and `X509_V_FLAG_PARTIAL_CHAIN` (default: `false`)
-
+* `skip_labels` - Skip all label fields from the metadata.
+* `skip_container_metadata` - Skip some of the container data of the metadata. The metadata will not contain the container_image and container_image_id fields.
+* `skip_master_url` - Skip the master_url field from the metadata.
+* `skip_namespace_metadata` - Skip the namespace_id field from the metadata. The fetch_namespace_metadata function will be skipped. The plugin will be faster and cpu consumption will be less. 
 **NOTE:** As of the release 2.1.x of this plugin, it no longer supports parsing the source message into JSON and attaching it to the
 payload.  The following configuration options are removed:
 

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -76,6 +76,10 @@ module Fluent::Plugin
     # to trust the intermediate CA certs we do have, set this to `true` - this corresponds to
     # the openssl s_client -partial_chain flag and X509_V_FLAG_PARTIAL_CHAIN
     config_param :ssl_partial_chain, :bool, default: false
+    config_param :skip_labels, :bool, default: false
+    config_param :skip_container_metadata, :bool, default: false
+    config_param :skip_master_url, :bool, default: false
+    config_param :skip_namespace_metadata, :bool, default: false
 
     def fetch_pod_metadata(namespace_name, pod_name)
       log.trace("fetching pod metadata: #{namespace_name}/#{pod_name}") if log.trace?
@@ -291,7 +295,7 @@ module Fluent::Plugin
       if @kubernetes_url.present?
         pod_metadata = get_pod_metadata(container_id, namespace_name, pod_name, create_time, batch_miss_cache)
 
-        if (pod_metadata.include? 'containers') && (pod_metadata['containers'].include? container_id)
+        if (pod_metadata.include? 'containers') && (pod_metadata['containers'].include? container_id) && !@skip_container_metadata
           metadata['kubernetes']['container_image'] = pod_metadata['containers'][container_id]['image']
           metadata['kubernetes']['container_image_id'] = pod_metadata['containers'][container_id]['image_id']
         end

--- a/lib/fluent/plugin/kubernetes_metadata_common.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_common.rb
@@ -32,10 +32,12 @@ module KubernetesMetadata
     end
 
     def parse_namespace_metadata(namespace_object)
-      labels = syms_to_strs(namespace_object['metadata']['labels'].to_h)
+      labels = String.new
+      labels = syms_to_strs(namespace_object['metadata']['labels'].to_h) unless @skip_labels
+
       annotations = match_annotations(syms_to_strs(namespace_object['metadata']['annotations'].to_h))
       if @de_dot
-        self.de_dot!(labels)
+        self.de_dot!(labels) unless @skip_labels
         self.de_dot!(annotations)
       end
       kubernetes_metadata = {
@@ -48,10 +50,12 @@ module KubernetesMetadata
     end
 
     def parse_pod_metadata(pod_object)
-      labels = syms_to_strs(pod_object['metadata']['labels'].to_h)
+      labels = String.new
+      labels = syms_to_strs(pod_object['metadata']['labels'].to_h) unless @skip_labels
+
       annotations = match_annotations(syms_to_strs(pod_object['metadata']['annotations'].to_h))
       if @de_dot
-        self.de_dot!(labels)
+        self.de_dot!(labels) unless @skip_labels
         self.de_dot!(annotations)
       end
 
@@ -61,11 +65,17 @@ module KubernetesMetadata
         pod_object['status']['containerStatuses'].each do|container_status|
           # get plain container id (eg. docker://hash -> hash)
           container_id = container_status['containerID'].sub /^[-_a-zA-Z0-9]+:\/\//, ''
-          container_meta[container_id] = {
-              'name' => container_status['name'],
-              'image' => container_status['image'],
-              'image_id' => container_status['imageID']
-          }
+          unless @skip_container_metadata
+            container_meta[container_id] = {
+                'name' => container_status['name'],
+                'image' => container_status['image'],
+                'image_id' => container_status['imageID']
+            }
+          else
+            container_meta[container_id] = {
+                'name' => container_status['name']
+            }
+          end
         end
       rescue
         log.debug("parsing container meta information failed for: #{pod_object['metadata']['namespace']}/#{pod_object['metadata']['name']} ")
@@ -76,11 +86,11 @@ module KubernetesMetadata
           'pod_id'         => pod_object['metadata']['uid'],
           'pod_name'       => pod_object['metadata']['name'],
           'containers'     => syms_to_strs(container_meta),
-          'labels'         => labels,
-          'host'           => pod_object['spec']['nodeName'],
-          'master_url'     => @kubernetes_url
+          'host'           => pod_object['spec']['nodeName']
       }
       kubernetes_metadata['annotations'] = annotations unless annotations.empty?
+      kubernetes_metadata['labels'] = labels unless labels.empty?
+      kubernetes_metadata['master_url'] = @kubernetes_url unless @skip_master_url
       return kubernetes_metadata
     end
 

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -938,5 +938,33 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
         assert_equal(expected_kube_metadata, filtered[1])
       end
     end
+
+    test 'with docker & kubernetes metadata using skip config params' do
+      VCR.use_cassette('kubernetes_docker_metadata') do
+        filtered = emit({},'
+          kubernetes_url https://localhost:8443
+          watch false
+          cache_size 1
+          skip_labels true
+          skip_container_metadata true
+          skip_master_url true
+          skip_namespace_metadata true
+        ')
+        expected_kube_metadata = {
+            'docker' => {
+                'container_id' => '49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
+            },
+            'kubernetes' => {
+                'host'               => 'jimmi-redhat.localnet',
+                'pod_name'           => 'fabric8-console-controller-98rqc',
+                'container_name'     => 'fabric8-console-container',
+                'namespace_name'     => 'default',
+                'pod_id'             => 'c76927af-f563-11e4-b32d-54ee7527188d'
+            }
+        }
+
+        assert_equal(expected_kube_metadata, filtered[0])
+      end
+    end
   end
 end


### PR DESCRIPTION
Our intention is to introduce some config options to be able to skip some fields in order to save significant storage capacity and hopefully some CPU cycles as well. Using default values the original behavior won't be changed.

We haven't found any alternative plugin to use instead this one. We know that additional plugins can be put at the end of the processing chain to filter out unnecessary fields, but we feel that it would be optimal (from CPU perspective) to not to collect them at a first place.

This feature is using 4 config parameter to skip some field of the metadata.  If these parameters (as the default value) are set to false, then the plugin works normally. But these parameters can switch independently the labels, container_metadata, master_url and namespace_metadata.