### PR TITLE
Update kubeclient version

### DIFF
--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 2']
   gem.add_runtime_dependency "lru_redux"
-  gem.add_runtime_dependency "kubeclient", "~> 1.1.4"
+  gem.add_runtime_dependency "kubeclient", "~> 4.4.0"
 
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
## Title
Update kubeclient version

### Problem
The previous version does not have the same breadth of capabilities that the up-to-date version has.

### Solution
Change the kubeclient version being used to the most up to date version.
(I would also be open to using slightly older kubeclient versions if there is good reason for doing so, but the current version is extremely out of date.)