### PR TITLE
Improve Kubernetes pod lookups

### DIFF
--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "lru_redux"
   gem.add_runtime_dependency "kubeclient", '< 5'
 
-  gem.add_development_dependency "bundler", "~> 1.3"
+  gem.add_development_dependency "bundler", "~> 2.0.2"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "minitest", "~> 4.0"
   gem.add_development_dependency "test-unit", "~> 3.0.2"

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -24,22 +24,24 @@ module KubernetesMetadata
     include ::KubernetesMetadata::Common
 
     def start_pod_watch
-      field_selector = ''
       if ENV['K8S_NODE_NAME']
         field_selector = 'spec.nodeName=' + ENV['K8S_NODE_NAME']
       end
       begin
-        pods = @client.get_pods(
-          resource_version: 0,  # Fetch from API server.
-          field_selector: field_selector)
+        options = {
+          resource_version: 0  # Fetch from API server.
+        }
+        if field_selector
+          options[:field_selector] = field_selector
+        end
+        pods = @client.get_pods(options)
         pods.each do |pod|
           cache_key = pod.metadata['uid']
           @cache[cache_key] = parse_pod_metadata(pod)
           @stats.bump(:pod_cache_host_updates)
         end
-        watcher = @client.watch_pods(
-          resource_version: pods.resourceVersion,
-          field_selector: field_selector)
+        options[:resource_version] = pods.resourceVersion
+        watcher = @client.watch_pods(options)
       rescue Exception => e
         message = "Exception encountered fetching metadata from Kubernetes API endpoint: #{e.message}"
         message += " (#{e.response})" if e.respond_to?(:response)

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -29,7 +29,7 @@ module KubernetesMetadata
       end
       begin
         options = {
-          resource_version: 0  # Fetch from API server.
+          resource_version: '0'  # Fetch from API server.
         }
         if field_selector
           options[:field_selector] = field_selector

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -54,9 +54,11 @@ module KubernetesMetadata
             if cached
               @cache[cache_key] = parse_pod_metadata(notice.object)
               @stats.bump(:pod_cache_watch_updates)
-            else
+            elsif ENV['K8S_NODE_NAME'] == notice.object['spec']['nodeName'] then
               @cache[cache_key] = parse_pod_metadata(notice.object)
               @stats.bump(:pod_cache_host_updates)
+            else
+              @stats.bump(:pod_cache_watch_misses)
             end
           when 'DELETED'
             # ignore and let age out for cases where pods

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -24,15 +24,12 @@ module KubernetesMetadata
     include ::KubernetesMetadata::Common
 
     def start_pod_watch
-      if ENV['K8S_NODE_NAME']
-        field_selector = 'spec.nodeName=' + ENV['K8S_NODE_NAME']
-      end
       begin
         options = {
           resource_version: '0'  # Fetch from API server.
         }
-        if field_selector
-          options[:field_selector] = field_selector
+        if ENV['K8S_NODE_NAME']
+          options[:field_selector] = 'spec.nodeName=' + ENV['K8S_NODE_NAME']
         end
         pods = @client.get_pods(options)
         pods.each do |pod|

--- a/test/plugin/test_watch_pods.rb
+++ b/test/plugin/test_watch_pods.rb
@@ -173,6 +173,14 @@ class DefaultPodWatchStrategyTest < WatchTest
       end
     end
 
+    test 'pod watch notice is ignored when info not cached and MODIFIED is received' do
+      @client.stub :watch_pods, [@modified] do
+       start_pod_watch
+       assert_equal(false, @cache.key?('modified_uid'))
+       assert_equal(1, @stats[:pod_cache_watch_misses])
+      end
+    end
+
     test 'pod MODIFIED cached when hostname matches' do
       orig_env_val = ENV['K8S_NODE_NAME']
       ENV['K8S_NODE_NAME'] = 'aNodeName'

--- a/test/plugin/test_watch_pods.rb
+++ b/test/plugin/test_watch_pods.rb
@@ -173,14 +173,6 @@ class DefaultPodWatchStrategyTest < WatchTest
       end
     end
 
-    test 'pod watch notice is ignored when info not cached and MODIFIED is received' do
-      @client.stub :watch_pods, [@modified] do
-       start_pod_watch
-       assert_equal(false, @cache.key?('modified_uid'))
-       assert_equal(1, @stats[:pod_cache_watch_misses])
-      end
-    end
-
     test 'pod MODIFIED cached when hostname matches' do
       orig_env_val = ENV['K8S_NODE_NAME']
       ENV['K8S_NODE_NAME'] = 'aNodeName'

--- a/test/plugin/watch_test.rb
+++ b/test/plugin/watch_test.rb
@@ -30,16 +30,16 @@ class WatchTest < Test::Unit::TestCase
       def @client.resourceVersion
         '12345'
       end
-      def @client.watch_pods(options)
+      def @client.watch_pods(options = {})
          []
       end
-      def @client.watch_namespaces(value)
+      def @client.watch_namespaces(options = {})
          []
       end
-      def @client.get_namespaces 
+      def @client.get_namespaces(options = {})
           self
       end
-      def @client.get_pods(options)
+      def @client.get_pods(options = {})
           self
       end
     end

--- a/test/plugin/watch_test.rb
+++ b/test/plugin/watch_test.rb
@@ -30,7 +30,7 @@ class WatchTest < Test::Unit::TestCase
       def @client.resourceVersion
         '12345'
       end
-      def @client.watch_pods(value, field_selector)
+      def @client.watch_pods(options)
          []
       end
       def @client.watch_namespaces(value)
@@ -39,7 +39,7 @@ class WatchTest < Test::Unit::TestCase
       def @client.get_namespaces 
           self
       end
-      def @client.get_pods(field_selector)
+      def @client.get_pods(options)
           self
       end
     end

--- a/test/plugin/watch_test.rb
+++ b/test/plugin/watch_test.rb
@@ -30,7 +30,7 @@ class WatchTest < Test::Unit::TestCase
       def @client.resourceVersion
         '12345'
       end
-      def @client.watch_pods(value)
+      def @client.watch_pods(value, field_selector)
          []
       end
       def @client.watch_namespaces(value)
@@ -39,7 +39,7 @@ class WatchTest < Test::Unit::TestCase
       def @client.get_namespaces 
           self
       end
-      def @client.get_pods
+      def @client.get_pods(field_selector)
           self
       end
     end


### PR DESCRIPTION
This PR contains the following related fixes to pod lookup performance:
1. Cache results from `get_pods`.
1. Restrict `get_pods` and `watch_pods` requests to the current host, if provided with the `K8S_NODE_NAME` environment variable.
1. Force lookup from API server cache by setting resourceVersion=0 in `get_pods` request.

Item #3 is only effective with https://github.com/abonas/kubeclient/pull/420, otherwise it's a harmless no-op (kubeclient will ignore the option).

Closes #187 