### PR TITLE
get rid of dependency on activesupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 
 gem 'codeclimate-test-reporter', '<1.0.0', :group => :test, :require => nil
-gem 'rubocop', require: false
+if RUBY_VERSION == "2.0.0"
+  gem 'rubocop', '<0.51.0', require: false
+else
+  gem 'rubocop', require: false
+end
 
 # Specify your gem's dependencies in fluent-plugin-add.gemspec
 gemspec

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -23,9 +23,18 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "fluentd", ">= 0.12.0"
   gem.add_runtime_dependency "lru_redux"
   gem.add_runtime_dependency "kubeclient", "~> 1.1.4"
+  if RUBY_VERSION == "2.0.0"
+    gem.add_runtime_dependency "public_suffix", "< 3"
+    gem.add_runtime_dependency "parallel", "< 1.14"
+    gem.add_runtime_dependency "rainbow", "< 3"
+  end
 
   gem.add_development_dependency "bundler", "~> 1.3"
-  gem.add_development_dependency "rake"
+  if RUBY_VERSION == "2.0.0"
+    gem.add_development_dependency "rake", "< 13"
+  else
+    gem.add_development_dependency "rake"
+  end
   gem.add_development_dependency "minitest", "~> 4.0"
   gem.add_development_dependency "test-unit", "~> 3.0.2"
   gem.add_development_dependency "test-unit-rr", "~> 1.0.3"

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -126,7 +126,7 @@ module Fluent
             metadata = parse_namespace_metadata(metadata)
             @stats.bump(:namespace_cache_api_updates)
             log.trace("parsed metadata for #{namespace_name}: #{metadata}") if log.trace?
-             @namespace_cache[metadata['namespace_id']] = metadata
+            @namespace_cache[metadata['namespace_id']] = metadata
             return metadata
           rescue Exception => e
             log.debug(e)
@@ -154,7 +154,6 @@ module Fluent
       end
 
       require 'kubeclient'
-      require 'active_support/core_ext/object/blank'
       require 'lru_redux'
       @stats = KubernetesMetadata::Stats.new
 

--- a/lib/fluent/plugin/kubernetes_metadata_common.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_common.rb
@@ -103,3 +103,29 @@ module KubernetesMetadata
 
   end
 end
+
+# copied from activesupport
+class Object
+  # An object is blank if it's false, empty, or a whitespace string.
+  # For example, +nil+, '', '   ', [], {}, and +false+ are all blank.
+  #
+  # This simplifies
+  #
+  #   !address || address.empty?
+  #
+  # to
+  #
+  #   address.blank?
+  #
+  # @return [true, false]
+  def blank?
+    respond_to?(:empty?) ? !!empty? : !self
+  end
+
+  # An object is present if it's not blank.
+  #
+  # @return [true, false]
+  def present?
+    !blank?
+  end
+end


### PR DESCRIPTION
Some transitive dependency on some newer project has crept in
via activesupport.  We only use activesupport for a couple of
trivial methods, so just implement those methods in our code.
Due to needing to support ruby 2.0.0, we have to lock down the
versions of several of the components we use.