### PR TITLE
Adds VERIFY_SSL env config support

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -204,6 +204,11 @@ module Fluent::Plugin
         end
       end
 
+      # Use verify_ssl configuration from env variable
+      if ENV['VERIFY_SSL'].present?
+      	@verify_ssl = ENV['VERIFY_SSL'] == "true" ? true : false
+      end
+
       # Use SSL certificate and bearer token from Kubernetes service account.
       if Dir.exist?(@secret_dir)
         log.debug "Found directory with secrets: #{@secret_dir}"


### PR DESCRIPTION
There are several issue reported on fluentd repo regarding issues with internal Kubernetes certificate verification. Something like this will help fix the things without the need to rebuild and maintain copy of fluentd-daemonset docker images.