### PR TITLE
Add retry logic in pod and namespace watches when Kubernetes API connection gets closed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ when true (default: `true`)
 * `skip_container_metadata` - Skip some of the container data of the metadata. The metadata will not contain the container_image and container_image_id fields.
 * `skip_master_url` - Skip the master_url field from the metadata.
 * `skip_namespace_metadata` - Skip the namespace_id field from the metadata. The fetch_namespace_metadata function will be skipped. The plugin will be faster and cpu consumption will be less.
+* `watch_retry_interval` - The time interval in seconds for retry backoffs when watch connections fail. (default: `10`)
 
 **NOTE:** As of the release 2.1.x of this plugin, it no longer supports parsing the source message into JSON and attaching it to the
 payload.  The following configuration options are removed:

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -291,6 +291,7 @@ module Fluent::Plugin
                 pod_watcher ||= get_pods_and_start_watcher
                 process_pod_watcher_notices(pod_watcher)
               rescue Exception => e
+                @stats.bump(:pod_watch_failures)
                 if Thread.current[:pod_watch_retry_count] <= @watch_retry_max_times
                   # Instead of raising exceptions and crashing Fluentd, swallow
                   # the exception and reset the watcher.
@@ -333,6 +334,7 @@ module Fluent::Plugin
                 namespace_watcher ||= get_namespaces_and_start_watcher
                 process_namespace_watcher_notices(namespace_watcher)
               rescue Exception => e
+                @stats.bump(:namespace_watch_failures)
                 if Thread.current[:namespace_watch_retry_count] <= @watch_retry_max_times
                   # Instead of raising exceptions and crashing Fluentd, swallow
                   # the exception and reset the watcher.

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -275,88 +275,12 @@ module Fluent::Plugin
 
         if @watch
           pod_thread = thread_create :"pod_watch_thread" do
-            # Any failures / exceptions in the initial setup should raise
-            # Fluent:ConfigError, so that users can inspect potential errors in
-            # the configuration.
-            pod_watcher = start_pod_watch
-            Thread.current[:pod_watch_retry_backoff_interval] = @watch_retry_interval
-            Thread.current[:pod_watch_retry_count] = 0
-
-            # Any failures / exceptions in the followup watcher notice
-            # processing will be swallowed and retried. These failures /
-            # exceptions could be caused by Kubernetes API being temporarily
-            # down. We assume the configuration is correct at this point.
-            while thread_current_running?
-              begin
-                pod_watcher ||= get_pods_and_start_watcher
-                process_pod_watcher_notices(pod_watcher)
-              rescue Exception => e
-                @stats.bump(:pod_watch_failures)
-                if Thread.current[:pod_watch_retry_count] <= @watch_retry_max_times
-                  # Instead of raising exceptions and crashing Fluentd, swallow
-                  # the exception and reset the watcher.
-                  log.info(
-                    "Exception encountered parsing pod watch event. The " \
-                    "connection might have been closed. Sleeping for " \
-                    "#{Thread.current[:pod_watch_retry_backoff_interval]} " \
-                    "seconds and resetting the pod watcher.", e)
-                  sleep(Thread.current[:pod_watch_retry_backoff_interval])
-                  Thread.current[:pod_watch_retry_count] += 1
-                  Thread.current[:pod_watch_retry_backoff_interval] *= @watch_retry_exponential_backoff_base
-                  pod_watcher = nil
-                else
-                  # Since retries failed for many times, log as errors instead
-                  # of info and raise exceptions and trigger Fluentd to restart.
-                  log.error(
-                    "Exception encountered parsing pod watch event. The " \
-                    "connection might have been closed. Retried " \
-                    "#{@watch_retry_max_times} times yet still failing.", e)
-                end
-              end
-            end
+            set_up_pod_thread
           end
           pod_thread.abort_on_exception = true
 
           namespace_thread = thread_create :"namespace_watch_thread" do
-            # Any failures / exceptions in the initial setup should raise
-            # Fluent:ConfigError, so that users can inspect potential errors in
-            # the configuration.
-            namespace_watcher = start_namespace_watch
-            Thread.current[:namespace_watch_retry_backoff_interval] = @watch_retry_interval
-            Thread.current[:namespace_watch_retry_count] = 0
-
-            # Any failures / exceptions in the followup watcher notice
-            # processing will be swallowed and retried. These failures /
-            # exceptions could be caused by Kubernetes API being temporarily
-            # down. We assume the configuration is correct at this point.
-            while thread_current_running?
-              begin
-                namespace_watcher ||= get_namespaces_and_start_watcher
-                process_namespace_watcher_notices(namespace_watcher)
-              rescue Exception => e
-                @stats.bump(:namespace_watch_failures)
-                if Thread.current[:namespace_watch_retry_count] <= @watch_retry_max_times
-                  # Instead of raising exceptions and crashing Fluentd, swallow
-                  # the exception and reset the watcher.
-                  log.info(
-                    "Exception encountered parsing namespace watch event. " \
-                    "The connection might have been closed. Sleeping for " \
-                    "#{Thread.current[:namespace_watch_retry_backoff_interval]} " \
-                    "seconds and resetting the namespace watcher.", e)
-                  sleep(Thread.current[:namespace_watch_retry_backoff_interval])
-                  Thread.current[:namespace_watch_retry_count] += 1
-                  Thread.current[:namespace_watch_retry_backoff_interval] *= @watch_retry_exponential_backoff_base
-                  namespace_watcher = nil
-                else
-                  # Since retries failed for many times, log as errors instead
-                  # of info and raise exceptions and trigger Fluentd to restart.
-                  log.error(
-                    "Exception encountered parsing namespace watch event. The " \
-                    "connection might have been closed. Retried " \
-                    "#{@watch_retry_max_times} times yet still failing.", e)
-                end
-              end
-            end
+            set_up_namespace_thread
           end
           namespace_thread.abort_on_exception = true
         end

--- a/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
@@ -49,7 +49,6 @@ module KubernetesMetadata
       end
       options[:resource_version] = namespaces.resourceVersion
       watcher = @client.watch_namespaces(options)
-      Thread.current[:namespace_watcher_alive] = true
       watcher
     end
 

--- a/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
@@ -53,18 +53,8 @@ module KubernetesMetadata
       watcher
     end
 
-    # Reset the namespace watcher if it's not alive.
-    def reset_namespace_watcher_if_needed(watcher)
-      if Thread.current[:namespace_watcher_alive]
-        watcher
-      else
-        get_namespaces_and_start_watcher
-      end
-    end
-
-    # Given a watcher, process the notices and handle retries by resetting the
-    # watcher if needed.
-    def process_namespace_watcher_notices_with_retries(watcher)
+    # Process a watcher notice and potentially raise an exception.
+    def process_namespace_watcher_notices(watcher)
       watcher.each do |notice|
         case notice.type
           when 'MODIFIED'
@@ -86,14 +76,6 @@ module KubernetesMetadata
             @stats.bump(:namespace_cache_watch_ignored)
         end
       end
-    rescue Exception => e
-      # Instead of raising exceptions and crashing Fluentd, swallow the
-      # exception and reset the watcher.
-      log.info "Exception encountered parsing namespace watch event. " \
-               "The connection might have been closed. " \
-               "Resetting the namespace watcher.", e
-      Thread.current[:namespace_watcher_alive] = false
-      sleep(@watch_retry_interval)
     end
   end
 end

--- a/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
@@ -24,7 +24,7 @@ module KubernetesMetadata
     include ::KubernetesMetadata::Common
 
     def start_namespace_watch
-      get_namespaces_and_start_watcher
+      return get_namespaces_and_start_watcher
     rescue Exception => e
       message = "start_namespace_watch: Exception encountered setting up " \
                 "namespace watch from Kubernetes API #{@apiVersion} endpoint " \

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -52,7 +52,6 @@ module KubernetesMetadata
       end
       options[:resource_version] = pods.resourceVersion
       watcher = @client.watch_pods(options)
-      Thread.current[:pod_watcher_alive] = true
       watcher
     end
 

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -24,29 +24,50 @@ module KubernetesMetadata
     include ::KubernetesMetadata::Common
 
     def start_pod_watch
-      begin
-        options = {
-          resource_version: '0'  # Fetch from API server.
-        }
-        if ENV['K8S_NODE_NAME']
-          options[:field_selector] = 'spec.nodeName=' + ENV['K8S_NODE_NAME']
-        end
-        pods = @client.get_pods(options)
-        pods.each do |pod|
-          cache_key = pod.metadata['uid']
-          @cache[cache_key] = parse_pod_metadata(pod)
-          @stats.bump(:pod_cache_host_updates)
-        end
-        options[:resource_version] = pods.resourceVersion
-        watcher = @client.watch_pods(options)
-      rescue Exception => e
-        message = "start_pod_watch: Exception encountered setting up pod watch from Kubernetes API #{@apiVersion} endpoint #{@kubernetes_url}: #{e.message}"
-        message += " (#{e.response})" if e.respond_to?(:response)
-        log.debug(message)
+      get_pods_and_start_watcher
+    rescue Exception => e
+      message = "start_pod_watch: Exception encountered setting up pod watch " \
+                "from Kubernetes API #{@apiVersion} endpoint " \
+                "#{@kubernetes_url}: #{e.message}"
+      message += " (#{e.response})" if e.respond_to?(:response)
+      log.debug(message)
 
-        raise Fluent::ConfigError, message
+      raise Fluent::ConfigError, message
+    end
+
+    # List all pods, record the resourceVersion and return a watcher starting
+    # from that resourceVersion.
+    def get_pods_and_start_watcher
+      options = {
+        resource_version: '0'  # Fetch from API server.
+      }
+      if ENV['K8S_NODE_NAME']
+        options[:field_selector] = 'spec.nodeName=' + ENV['K8S_NODE_NAME']
       end
+      pods = @client.get_pods(options)
+      pods.each do |pod|
+        cache_key = pod.metadata['uid']
+        @cache[cache_key] = parse_pod_metadata(pod)
+        @stats.bump(:pod_cache_host_updates)
+      end
+      options[:resource_version] = pods.resourceVersion
+      watcher = @client.watch_pods(options)
+      Thread.current[:pod_watcher_alive] = true
+      watcher
+    end
 
+    # Reset the pod watcher if it's not alive.
+    def reset_pod_watcher_if_needed(watcher)
+      if Thread.current[:pod_watcher_alive]
+        watcher
+      else
+        get_pods_and_start_watcher
+      end
+    end
+
+    # Given a watcher, process the notices and handle retries by resetting the
+    # watcher if needed.
+    def process_pod_watcher_notices_with_retries(watcher)
       watcher.each do |notice|
         case notice.type
           when 'MODIFIED'
@@ -71,6 +92,14 @@ module KubernetesMetadata
             @stats.bump(:pod_cache_watch_ignored)
         end
       end
+    rescue Exception => e
+      # Instead of raising exceptions and crashing Fluentd, swallow the
+      # exception and reset the watcher.
+      log.info "Exception encountered parsing pod watch event. " \
+               "The connection might have been closed. " \
+               "Resetting the pod watcher.", e
+      Thread.current[:pod_watcher_alive] = false
+      sleep(@watch_retry_interval)
     end
   end
 end

--- a/test/plugin/test_watch_namespaces.rb
+++ b/test/plugin/test_watch_namespaces.rb
@@ -74,7 +74,7 @@ class WatchNamespacesTestTest < WatchTest
 
     test 'namespace list caches namespaces' do
       @client.stub :get_namespaces, @initial do
-        start_namespace_watch
+        process_namespace_watcher_notices(start_namespace_watch)
         assert_equal(true, @namespace_cache.key?('initial_uid'))
         assert_equal(true, @namespace_cache.key?('modified_uid'))
         assert_equal(2, @stats[:namespace_cache_host_updates])
@@ -86,7 +86,7 @@ class WatchNamespacesTestTest < WatchTest
       ENV['K8S_NODE_NAME'] = 'aNodeName'
       @client.stub :get_namespaces, @initial do
         @client.stub :watch_namespaces, [@modified] do
-          start_namespace_watch
+          process_namespace_watcher_notices(start_namespace_watch)
           assert_equal(2, @stats[:namespace_cache_host_updates])
           assert_equal(1, @stats[:namespace_cache_watch_updates])
         end
@@ -96,7 +96,7 @@ class WatchNamespacesTestTest < WatchTest
 
     test 'namespace watch ignores CREATED' do
       @client.stub :watch_namespaces, [@created] do
-       start_namespace_watch
+       process_namespace_watcher_notices(start_namespace_watch)
        assert_equal(false, @namespace_cache.key?('created_uid'))
        assert_equal(1, @stats[:namespace_cache_watch_ignored])
       end
@@ -104,7 +104,7 @@ class WatchNamespacesTestTest < WatchTest
 
     test 'namespace watch ignores MODIFIED when info not in cache' do
       @client.stub :watch_namespaces, [@modified] do
-       start_namespace_watch
+       process_namespace_watcher_notices(start_namespace_watch)
        assert_equal(false, @namespace_cache.key?('modified_uid'))
        assert_equal(1, @stats[:namespace_cache_watch_misses])
       end
@@ -113,7 +113,7 @@ class WatchNamespacesTestTest < WatchTest
     test 'namespace watch updates cache when MODIFIED is received and info is cached' do
       @namespace_cache['modified_uid'] = {}
       @client.stub :watch_namespaces, [@modified] do
-       start_namespace_watch
+       process_namespace_watcher_notices(start_namespace_watch)
        assert_equal(true, @namespace_cache.key?('modified_uid'))
        assert_equal(1, @stats[:namespace_cache_watch_updates])
       end
@@ -122,7 +122,7 @@ class WatchNamespacesTestTest < WatchTest
     test 'namespace watch ignores DELETED' do
       @namespace_cache['deleted_uid'] = {}
       @client.stub :watch_namespaces, [@deleted] do
-       start_namespace_watch
+       process_namespace_watcher_notices(start_namespace_watch)
        assert_equal(true, @namespace_cache.key?('deleted_uid'))
        assert_equal(1, @stats[:namespace_cache_watch_deletes_ignored])
       end

--- a/test/plugin/test_watch_pods.rb
+++ b/test/plugin/test_watch_pods.rb
@@ -142,7 +142,7 @@ class DefaultPodWatchStrategyTest < WatchTest
       orig_env_val = ENV['K8S_NODE_NAME']
       ENV['K8S_NODE_NAME'] = 'aNodeName'
       @client.stub :get_pods, @initial do
-        start_pod_watch
+        process_pod_watcher_notices(start_pod_watch)
         assert_equal(true, @cache.key?('initial_uid'))
         assert_equal(true, @cache.key?('modified_uid'))
         assert_equal(2, @stats[:pod_cache_host_updates])
@@ -155,7 +155,7 @@ class DefaultPodWatchStrategyTest < WatchTest
       ENV['K8S_NODE_NAME'] = 'aNodeName'
       @client.stub :get_pods, @initial do
         @client.stub :watch_pods, [@modified] do
-          start_pod_watch
+          process_pod_watcher_notices(start_pod_watch)
           assert_equal(2, @stats[:pod_cache_host_updates])
           assert_equal(1, @stats[:pod_cache_watch_updates])
         end
@@ -166,7 +166,7 @@ class DefaultPodWatchStrategyTest < WatchTest
     test 'pod watch notice ignores CREATED' do
       @client.stub :get_pods, @initial do
         @client.stub :watch_pods, [@created] do
-          start_pod_watch
+          process_pod_watcher_notices(start_pod_watch)
           assert_equal(false, @cache.key?('created_uid'))
           assert_equal(1, @stats[:pod_cache_watch_ignored])
         end
@@ -175,7 +175,7 @@ class DefaultPodWatchStrategyTest < WatchTest
 
     test 'pod watch notice is ignored when info not cached and MODIFIED is received' do
       @client.stub :watch_pods, [@modified] do
-       start_pod_watch
+       process_pod_watcher_notices(start_pod_watch)
        assert_equal(false, @cache.key?('modified_uid'))
        assert_equal(1, @stats[:pod_cache_watch_misses])
       end
@@ -185,7 +185,7 @@ class DefaultPodWatchStrategyTest < WatchTest
       orig_env_val = ENV['K8S_NODE_NAME']
       ENV['K8S_NODE_NAME'] = 'aNodeName'
       @client.stub :watch_pods, [@modified] do
-       start_pod_watch
+       process_pod_watcher_notices(start_pod_watch)
        assert_equal(true, @cache.key?('modified_uid'))
        assert_equal(1, @stats[:pod_cache_host_updates])
       end
@@ -195,7 +195,7 @@ class DefaultPodWatchStrategyTest < WatchTest
     test 'pod watch notice is updated when MODIFIED is received' do
       @cache['modified_uid'] = {}
       @client.stub :watch_pods, [@modified] do
-       start_pod_watch
+       process_pod_watcher_notices(start_pod_watch)
        assert_equal(true, @cache.key?('modified_uid'))
        assert_equal(1, @stats[:pod_cache_watch_updates])
       end
@@ -204,7 +204,7 @@ class DefaultPodWatchStrategyTest < WatchTest
     test 'pod watch notice is ignored when delete is received' do
       @cache['deleted_uid'] = {}
       @client.stub :watch_pods, [@deleted] do
-       start_pod_watch
+       process_pod_watcher_notices(start_pod_watch)
        assert_equal(true, @cache.key?('deleted_uid'))
        assert_equal(1, @stats[:pod_cache_watch_delete_ignored])
       end

--- a/test/plugin/test_watch_pods.rb
+++ b/test/plugin/test_watch_pods.rb
@@ -210,4 +210,16 @@ class DefaultPodWatchStrategyTest < WatchTest
       end
     end
 
+    test 'pod watch retries when exceptions are encountered' do
+      @client.stub :get_pods, @initial do
+        @client.stub :watch_pods, [[@created, @exception_raised]] do
+          assert_raise Fluent::UnrecoverableError do
+            set_up_pod_thread
+          end
+          assert_equal(3, @stats[:pod_watch_failures])
+          assert_equal(2, Thread.current[:pod_watch_retry_count])
+          assert_equal(4, Thread.current[:pod_watch_retry_backoff_interval])
+        end
+      end
+    end
 end

--- a/test/plugin/watch_test.rb
+++ b/test/plugin/watch_test.rb
@@ -20,38 +20,54 @@ require_relative '../helper'
 require 'ostruct'
 
 class WatchTest < Test::Unit::TestCase
-   
-    setup do
-      @annotations_regexps = []
-      @namespace_cache = {}
-      @cache = {}
-      @stats = KubernetesMetadata::Stats.new
-      @client = OpenStruct.new
-      def @client.resourceVersion
-        '12345'
-      end
-      def @client.watch_pods(options = {})
-         []
-      end
-      def @client.watch_namespaces(options = {})
-         []
-      end
-      def @client.get_namespaces(options = {})
-          self
-      end
-      def @client.get_pods(options = {})
-          self
-      end
+
+  def thread_current_running?
+    true
+  end
+
+  setup do
+    @annotations_regexps = []
+    @namespace_cache = {}
+    @watch_retry_max_times = 2
+    @watch_retry_interval = 1
+    @watch_retry_exponential_backoff_base = 2
+    @cache = {}
+    @stats = KubernetesMetadata::Stats.new
+
+    @client = OpenStruct.new
+    def @client.resourceVersion
+      '12345'
+    end
+    def @client.watch_pods(options = {})
+      []
+    end
+    def @client.watch_namespaces(options = {})
+      []
+    end
+    def @client.get_namespaces(options = {})
+      self
+    end
+    def @client.get_pods(options = {})
+      self
     end
 
-    def watcher=(value)
+    @exception_raised = OpenStruct.new
+    def @exception_raised.each
+      raise Exception
     end
+  end
 
-    def log
-        logger = {}
-        def logger.debug(message)
-        end
-        logger
+  def watcher=(value)
+  end
+
+  def log
+    logger = {}
+    def logger.debug(message)
     end
-
+    def logger.info(message, error)
+    end
+    def logger.error(message, error)
+    end
+    logger
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/194.