### PR TITLE
Add pod IP to kubernetes metadata

### DIFF
--- a/lib/fluent/plugin/kubernetes_metadata_common.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_common.rb
@@ -86,7 +86,8 @@ module KubernetesMetadata
           'pod_id'         => pod_object['metadata']['uid'],
           'pod_name'       => pod_object['metadata']['name'],
           'containers'     => syms_to_strs(container_meta),
-          'host'           => pod_object['spec']['nodeName']
+          'host'           => pod_object['spec']['nodeName'],
+          'pod_ip'         => pod_object['status']['podIP']
       }
       kubernetes_metadata['annotations'] = annotations unless annotations.empty?
       kubernetes_metadata['labels'] = labels unless labels.empty?


### PR DESCRIPTION
The pod IP can provide very useful information in Graylog, when trying to link load balancer logs and pod logs in Graylog. 
When using a custom load balancer setup (with nginx), nginx will only log the pod ips, and having the pod ip enriched to the pod logs makes it easier to map lb / pod logs.