### PR TITLE
Improve Kubernetes namespace lookups.

### DIFF
--- a/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
@@ -25,12 +25,22 @@ module KubernetesMetadata
 
     def start_namespace_watch
       begin
-        resource_version = @client.get_namespaces.resourceVersion
-        watcher          = @client.watch_namespaces(resource_version)
+        options = {
+          resource_version: '0'  # Fetch from API server.
+        }
+        namespaces = @client.get_namespaces(options)
+        namespaces.each do |namespace|
+          cache_key = namespace.metadata['uid']
+          @namespace_cache[cache_key] = parse_namespace_metadata(namespace)
+          @stats.bump(:namespace_cache_host_updates)
+        end
+        options[:resource_version] = namespaces.resourceVersion
+        watcher = @client.watch_namespaces(options)
       rescue Exception=>e
         message = "start_namespace_watch: Exception encountered setting up namespace watch from Kubernetes API #{@apiVersion} endpoint #{@kubernetes_url}: #{e.message}"
         message += " (#{e.response})" if e.respond_to?(:response)
         log.debug(message)
+
         raise Fluent::ConfigError, message
       end
       watcher.each do |notice|
@@ -50,7 +60,7 @@ module KubernetesMetadata
             @stats.bump(:namespace_cache_watch_deletes_ignored)
           else
             # Don't pay attention to creations, since the created namespace may not
-            # be used by any pod on this node.
+            # be used by any namespace on this node.
             @stats.bump(:namespace_cache_watch_ignored)
         end
       end

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -40,8 +40,9 @@ module KubernetesMetadata
         options[:resource_version] = pods.resourceVersion
         watcher = @client.watch_pods(options)
       rescue Exception => e
-        message = "Exception encountered fetching metadata from Kubernetes API endpoint: #{e.message}"
+        message = "start_pod_watch: Exception encountered setting up pod watch from Kubernetes API #{@apiVersion} endpoint #{@kubernetes_url}: #{e.message}"
         message += " (#{e.response})" if e.respond_to?(:response)
+        log.debug(message)
 
         raise Fluent::ConfigError, message
       end


### PR DESCRIPTION
* Cache results from get_namespaces.
* Force lookup from API server cache by setting resourceVersion=0 in get_namespaces request.