### PR TITLE
Use native threads instead of the thread helper library.

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -271,10 +271,10 @@ module Fluent::Plugin
         end
 
         if @watch
-          pod_thread = Thread.new(self) { |this| this.setup_pod_thread }
+          pod_thread = Thread.new(self) { |this| this.set_up_pod_thread }
           pod_thread.abort_on_exception = true
 
-          namespace_thread = Thread.new(self) { |title| this.setup_namespace_thread }
+          namespace_thread = Thread.new(self) { |title| this.set_up_namespace_thread }
           namespace_thread.abort_on_exception = true
         end
       end

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -23,7 +23,6 @@ require_relative 'kubernetes_metadata_stats'
 require_relative 'kubernetes_metadata_watch_namespaces'
 require_relative 'kubernetes_metadata_watch_pods'
 
-require 'fluent/plugin_helper/thread'
 require 'fluent/plugin/filter'
 require 'resolv'
 
@@ -38,8 +37,6 @@ module Fluent::Plugin
     include KubernetesMetadata::WatchPods
 
     Fluent::Plugin.register_filter('kubernetes_metadata', self)
-
-    helpers :thread
 
     config_param :kubernetes_url, :string, default: nil
     config_param :cache_size, :integer, default: 1000
@@ -274,14 +271,10 @@ module Fluent::Plugin
         end
 
         if @watch
-          pod_thread = thread_create :"pod_watch_thread" do
-            set_up_pod_thread
-          end
+          pod_thread = Thread.new(self) { |this| this.setup_pod_thread }
           pod_thread.abort_on_exception = true
 
-          namespace_thread = thread_create :"namespace_watch_thread" do
-            set_up_namespace_thread
-          end
+          namespace_thread = Thread.new(self) { |title| this.setup_namespace_thread }
           namespace_thread.abort_on_exception = true
         end
       end

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -274,7 +274,7 @@ module Fluent::Plugin
           pod_thread = Thread.new(self) { |this| this.set_up_pod_thread }
           pod_thread.abort_on_exception = true
 
-          namespace_thread = Thread.new(self) { |title| this.set_up_namespace_thread }
+          namespace_thread = Thread.new(self) { |this| this.set_up_namespace_thread }
           namespace_thread.abort_on_exception = true
         end
       end

--- a/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
@@ -35,7 +35,7 @@ module KubernetesMetadata
       # processing will be swallowed and retried. These failures /
       # exceptions could be caused by Kubernetes API being temporarily
       # down. We assume the configuration is correct at this point.
-      while thread_current_running?
+      while true
         begin
           namespace_watcher ||= get_namespaces_and_start_watcher
           process_namespace_watcher_notices(namespace_watcher)

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -35,7 +35,7 @@ module KubernetesMetadata
       # processing will be swallowed and retried. These failures /
       # exceptions could be caused by Kubernetes API being temporarily
       # down. We assume the configuration is correct at this point.
-      while thread_current_running?
+      while true
         begin
           pod_watcher ||= get_pods_and_start_watcher
           process_pod_watcher_notices(pod_watcher)


### PR DESCRIPTION
This change results in a significant reduction of memory usage by avoiding the thread map in the thread helper. 

The thread helper is not necessary for this functionality, threads this plugin creates do not need to be synchronized with the process shutdown, as they are asynchronous processes that collect data in the background to help facilitate the enrichment of logs.