### PR TITLE
Init watch_retry_count to 0 to avoid nil error.

### DIFF
--- a/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
@@ -29,6 +29,7 @@ module KubernetesMetadata
       # the configuration.
       namespace_watcher = start_namespace_watch
       Thread.current[:namespace_watch_retry_backoff_interval] = @watch_retry_interval
+      Thread.current[:namespace_watch_retry_count] = 0
 
       # Any failures / exceptions in the followup watcher notice
       # processing will be swallowed and retried. These failures /

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -29,6 +29,7 @@ module KubernetesMetadata
       # the configuration.
       pod_watcher = start_pod_watch
       Thread.current[:pod_watch_retry_backoff_interval] = @watch_retry_interval
+      Thread.current[:pod_watch_retry_count] = 0
 
       # Any failures / exceptions in the followup watcher notice
       # processing will be swallowed and retried. These failures /


### PR DESCRIPTION
Fixes https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/222.