### PR TITLE
Add 410 Gone handling for namespace watch

### DIFF
--- a/lib/fluent/plugin/kubernetes_metadata_common.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_common.rb
@@ -19,6 +19,12 @@
 module KubernetesMetadata
   module Common
 
+    class GoneError < StandardError
+      def initialize(msg="410 Gone")
+        super
+      end
+    end
+
     def match_annotations(annotations)
       result = {}
       @annotations_regexps.each do |regexp|


### PR DESCRIPTION
@jcantrill This is a follow-up to the PR I submitted last week to add handling for 410 Gone responses on the pod watch.

This PR makes two changes:
1. It adds the same handling for the namespace watch.
2. I changed the log level of the message from debug to info. Based on my experience running this in the wild, this is a message that we should print with the default log level. It's important for folks to know this is happening and that we're handling it.

This fixes issue #246 