### PR TITLE
run tests with bundler + allow running a single test file

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'bundler/setup'
 require 'codeclimate-test-reporter'
 SimpleCov.start do
   formatter SimpleCov::Formatter::MultiFormatter.new [
@@ -31,8 +32,14 @@ require 'fileutils'
 require 'fluent/log'
 require 'fluent/test'
 require 'minitest/autorun'
-require 'webmock/test_unit'
 require 'vcr'
+require 'ostruct'
+require 'fluent/plugin/filter_kubernetes_metadata'
+require 'fluent/test/driver/filter'
+require 'kubeclient'
+
+require 'webmock/test_unit'
+WebMock.disable_net_connect!
 
 VCR.configure do |config|
   config.cassette_library_dir = 'test/cassettes'
@@ -61,4 +68,13 @@ def ipv6_enabled?
   rescue
     false
   end
+end
+
+# TEST_NAME='foo' ruby test_file.rb to run a single test case
+if ENV["TEST_NAME"]
+  (class << Test::Unit::TestCase; self; end).prepend(Module.new do
+    def test(name)
+      super if name == ENV["TEST_NAME"]
+    end
+  end)
 end

--- a/test/plugin/test_cache_stats.rb
+++ b/test/plugin/test_cache_stats.rb
@@ -17,12 +17,9 @@
 # limitations under the License.
 #
 require_relative '../helper'
-require 'fluent/plugin/kubernetes_metadata_stats'
-require 'webmock/test_unit'
-WebMock.disable_net_connect!
 
 class KubernetesMetadataCacheStatsTest < Test::Unit::TestCase
-  
+
     test 'watch stats' do
       require 'lru_redux'
       stats = KubernetesMetadata::Stats.new
@@ -32,5 +29,5 @@ class KubernetesMetadataCacheStatsTest < Test::Unit::TestCase
 
       assert_equal("stats - deleted: 2, missed: 1", stats.to_s)
     end
-    
+
 end

--- a/test/plugin/test_cache_strategy.rb
+++ b/test/plugin/test_cache_strategy.rb
@@ -17,11 +17,6 @@
 # limitations under the License.
 #
 require_relative '../helper'
-require_relative '../../lib/fluent/plugin/kubernetes_metadata_cache_strategy'
-require_relative '../../lib/fluent/plugin/kubernetes_metadata_stats'
-require 'lru_redux'
-require 'webmock/test_unit'
-WebMock.disable_net_connect!
 
 class TestCacheStrategy
     include KubernetesMetadata::CacheStrategy
@@ -56,7 +51,7 @@ class TestCacheStrategy
 end
 
 class KubernetesMetadataCacheStrategyTest < Test::Unit::TestCase
-  
+
     def setup
        @strategy = TestCacheStrategy.new
        @cache_key = 'some_long_container_id'
@@ -114,7 +109,7 @@ class KubernetesMetadataCacheStrategyTest < Test::Unit::TestCase
         # we ever will have and should allow us to process all the deleted
         # pod records
         exp = {
-            'pod_id'=> @cache_key, 
+            'pod_id'=> @cache_key,
             'namespace_id'=> @namespace_uuid
         }
         @strategy.stub :fetch_pod_metadata, {} do
@@ -175,7 +170,7 @@ class KubernetesMetadataCacheStrategyTest < Test::Unit::TestCase
         end
         assert_equal({}, @strategy.get_pod_metadata(@cache_key,'namespace', 'pod', @time, batch_miss_cache))
     end
-    
+
     test 'when metadata is not cached and no metadata can be fetched and allowing orphans for multiple records' do
         # we should never see this since pod meta should not be retrievable
         # unless the namespace exists

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -17,11 +17,6 @@
 # limitations under the License.
 #
 require_relative '../helper'
-require 'fluent/test/driver/filter'
-require 'fluent/plugin/filter_kubernetes_metadata'
-
-require 'webmock/test_unit'
-WebMock.disable_net_connect!
 
 class KubernetesMetadataFilterTest < Test::Unit::TestCase
   include Fluent

--- a/test/plugin/test_watch_namespaces.rb
+++ b/test/plugin/test_watch_namespaces.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 require_relative '../helper'
-require 'ostruct'
 require_relative 'watch_test'
 
 class WatchNamespacesTestTest < WatchTest

--- a/test/plugin/test_watch_pods.rb
+++ b/test/plugin/test_watch_pods.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 require_relative '../helper'
-require 'ostruct'
 require_relative 'watch_test'
 
 class DefaultPodWatchStrategyTest < WatchTest

--- a/test/plugin/watch_test.rb
+++ b/test/plugin/watch_test.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 require_relative '../helper'
-require 'ostruct'
 
 class WatchTest < Test::Unit::TestCase
 


### PR DESCRIPTION
@fabric8io

also added `TEST_NAME='with records from journald and docker & kubernetes metadata, alternate form' ruby test/plugin/test_filter_kubernetes_metadata.rb`so a single test can be run