### PR TITLE
wait for watches to start so we do not run into lots of cache-misses …

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -278,6 +278,9 @@ module Fluent::Plugin
 
           namespace_thread = Thread.new(self) { |this| this.set_up_namespace_thread }
           namespace_thread.abort_on_exception = true
+
+          # wait for caches to be initialized to avoid of cache-misses right after booting
+          sleep 0.01 until pod_thread[:pod_watch_retry_count] && namespace_thread[:namespace_watch_retry_count]
         end
       end
       @time_fields = []


### PR DESCRIPTION
…when fluentd starts

this otherwise adds a ton of load especially when things are already in trouble from fluentd restarting
or new nodes coming up

hack for visibility:
```ruby
require 'kubeclient'
Kubeclient::Client.prepend(Module.new do
  def get_entity(resource_name, name, namespace = nil, options = {})
    puts "REQUEST get #{resource_name} #{name} #{namespace} #{options} pid: #{Process.pid}"
    super
  end

  def get_entities(entity_type, resource_name, options = {})
    puts "REQUEST list #{entity_type} #{resource_name} #{options} pid: #{Process.pid}"
    super
  end
end)
```

before:
```
fluentd-2mqwm fluentd 2020-09-02T19:32:14.222673911Z REQUEST list Pod pods {:resource_version=>"0", :field_selector=>"spec.nodeName=ip-x"} pid: 1
fluentd-2mqwm fluentd 2020-09-02T19:32:14.225997282Z REQUEST list Namespace namespaces {:resource_version=>"0"} pid: 1
fluentd-2mqwm fluentd 2020-09-02T19:32:15.399282019Z REQUEST list Namespace namespaces {:resource_version=>"0"} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.401283520Z REQUEST list Pod pods {:resource_version=>"0", :field_selector=>"spec.nodeName=ip-x"} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.582906978Z REQUEST get pods fluentd-2mqwm default {} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.595672756Z REQUEST get namespaces default  {} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.641617952Z REQUEST get pods fluentd-2mqwm default {} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.661498299Z REQUEST get namespaces default  {} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.759148497Z REQUEST get pods kube-node-problem-detector-wlkw2 kube-system {} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.770558914Z REQUEST get namespaces kube-system  {} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.787151415Z REQUEST get pods fluentd-2mqwm default {} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.799137603Z REQUEST get namespaces default  {} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.818106125Z REQUEST get pods datadog-gxz9x default {} pid: 16
fluentd-2mqwm fluentd 2020-09-02T19:32:15.834605970Z REQUEST get namespaces default  {} pid: 16
```

after:
```
fluentd-gzxgf fluentd 2020-09-02T19:44:21.259253204Z REQUEST list Pod pods {:resource_version=>"0", :field_selector=>"spec.nodeName=ip-X"} pid: 1
fluentd-gzxgf fluentd 2020-09-02T19:44:21.260905631Z REQUEST list Namespace namespaces {:resource_version=>"0"} pid: 1
```
and then just sweet silence :D