### PR TITLE
do not rescue Interrupt/SystemExit etc

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -96,7 +96,7 @@ module Fluent::Plugin
       @stats.bump(:pod_cache_api_updates)
       log.trace("parsed metadata for #{namespace_name}/#{pod_name}: #{metadata}") if log.trace?
       @cache[metadata['pod_id']] = metadata
-    rescue Exception => e
+    rescue => e
       @stats.bump(:pod_cache_api_nil_error)
       log.debug "Exception '#{e}' encountered fetching pod metadata from Kubernetes API #{@apiVersion} endpoint #{@kubernetes_url}"
       {}
@@ -124,7 +124,7 @@ module Fluent::Plugin
       @stats.bump(:namespace_cache_api_updates)
       log.trace("parsed metadata for #{namespace_name}: #{metadata}") if log.trace?
       @namespace_cache[metadata['namespace_id']] = metadata
-    rescue Exception => kube_error
+    rescue => kube_error
       @stats.bump(:namespace_cache_api_nil_error)
       log.debug "Exception '#{kube_error}' encountered fetching namespace metadata from Kubernetes API #{@apiVersion} endpoint #{@kubernetes_url}"
       {}

--- a/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_namespaces.rb
@@ -45,7 +45,7 @@ module KubernetesMetadata
           @stats.bump(:namespace_watch_gone_errors)
           log.info("410 Gone encountered. Restarting namespace watch to reset resource versions.", e)
           namespace_watcher = nil
-        rescue Exception => e
+        rescue => e
           @stats.bump(:namespace_watch_failures)
           if Thread.current[:namespace_watch_retry_count] < @watch_retry_max_times
             # Instead of raising exceptions and crashing Fluentd, swallow
@@ -74,8 +74,8 @@ module KubernetesMetadata
     end
 
     def start_namespace_watch
-      return get_namespaces_and_start_watcher
-    rescue Exception => e
+      get_namespaces_and_start_watcher
+    rescue => e
       message = "start_namespace_watch: Exception encountered setting up " \
                 "namespace watch from Kubernetes API #{@apiVersion} endpoint " \
                 "#{@kubernetes_url}: #{e.message}"
@@ -98,8 +98,7 @@ module KubernetesMetadata
         @stats.bump(:namespace_cache_host_updates)
       end
       options[:resource_version] = namespaces.resourceVersion
-      watcher = @client.watch_namespaces(options)
-      watcher
+      @client.watch_namespaces(options)
     end
 
     # Reset namespace watch retry count and backoff interval as there is a

--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -47,7 +47,7 @@ module KubernetesMetadata
           @stats.bump(:pod_watch_gone_errors)
           log.info("410 Gone encountered. Restarting pod watch to reset resource versions.", e)
           pod_watcher = nil
-        rescue Exception => e
+        rescue => e
           @stats.bump(:pod_watch_failures)
           if Thread.current[:pod_watch_retry_count] < @watch_retry_max_times
             # Instead of raising exceptions and crashing Fluentd, swallow
@@ -77,7 +77,7 @@ module KubernetesMetadata
 
     def start_pod_watch
       get_pods_and_start_watcher
-    rescue Exception => e
+    rescue => e
       message = "start_pod_watch: Exception encountered setting up pod watch " \
                 "from Kubernetes API #{@apiVersion} endpoint " \
                 "#{@kubernetes_url}: #{e.message}"


### PR DESCRIPTION
these should never be rescued since they could prevent shutdown signals like Ctrl+C and system Interrupts
(all exceptions that could be raised in these blocks inherit from StandardError and will still be rescued)