### PR TITLE
Convert plugin to use filter method instead of filter_stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby
+
+ADD . /plugin
+
+WORKDIR /plugin
+
+RUN apt update && apt install -y build-essential cmake
+
+RUN bundle install
+
+CMD rake test


### PR DESCRIPTION
Hello! 

We love this plugin and were using it to pull metadata from k8s. While looking for performance improvements, we noticed it was the only plugin in our config to not take advantage of the [filter optimization done by fluentd](https://docs.fluentd.org/filter#filter-chain-optimization) because it was implementing the `filter_stream` method rather than the `filter` method. After a quick refactor over to the other method, we saw a 63% increase in our throughput.

We also added a Dockerfile we used to test that we found helpful and thought others would as well.