### PR TITLE
Add podIP to metadata filter

### DIFF
--- a/lib/fluent/plugin/kubernetes_metadata_common.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_common.rb
@@ -92,6 +92,7 @@ module KubernetesMetadata
         'namespace_name' => pod_object[:metadata][:namespace],
         'pod_id' => pod_object[:metadata][:uid],
         'pod_name' => pod_object[:metadata][:name],
+        'pod_ip' => pod_object[:status][:podIP],
         'containers' => syms_to_strs(container_meta),
         'host' => pod_object[:spec][:nodeName]
       }

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -246,6 +246,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -274,6 +275,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -306,6 +308,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -338,6 +341,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -446,6 +450,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             },
             'namespace_name' => 'default',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'kubernetes_io/test' => 'somevalue'
@@ -481,6 +486,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             },
             'namespace_name' => 'default',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'kubernetes.io/test' => 'somevalue'
@@ -528,6 +534,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -567,6 +574,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -612,6 +620,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'k8s-namespace-name',
             'namespace_id' => '8e0dc8fc-59f2-49f7-a3e2-ed0913e19d9f',
             'pod_id' => 'ebabf749-5fcd-4750-a3f0-aedd89476da8',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'k8s-test'
@@ -658,6 +667,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'journald-namespace-name',
             'namespace_id' => '8282888f-733f-4f23-a3d3-1fdfa3bdacf2',
             'pod_id' => '5e1c1e27-b637-4e81-80b6-6d8a8c404d3b',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'journald-test'
@@ -705,6 +715,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -738,6 +749,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -786,6 +798,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -819,6 +832,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'container_image' => 'fabric8/hawtio-kubernetes:latest',
             'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -859,6 +873,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'namespace_name' => 'default',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -951,6 +966,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
             'labels' => {
               'component' => 'fabric8Console'
@@ -984,7 +1000,8 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'pod_name' => 'fabric8-console-controller-98rqc',
             'container_name' => 'fabric8-console-container',
             'namespace_name' => 'default',
-            'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d'
+            'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8'
           }
         }
 

--- a/test/plugin/test_watch_pods.rb
+++ b/test/plugin/test_watch_pods.rb
@@ -45,6 +45,9 @@ class DefaultPodWatchStrategyTest < WatchTest
               name: 'bar',
               image: 'foo'
             }]
+          },
+          status: {
+            podIP: '172.17.0.8'
           }
         },
         {
@@ -63,6 +66,9 @@ class DefaultPodWatchStrategyTest < WatchTest
               name: 'bar',
               image: 'foo'
             }]
+          },
+          status: {
+            podIP: '172.17.0.8'
           }
         }
       ]
@@ -86,6 +92,9 @@ class DefaultPodWatchStrategyTest < WatchTest
             name: 'bar',
             image: 'foo'
           }]
+        },
+        status: {
+          podIP: '172.17.0.8'
         }
       }
     }
@@ -110,6 +119,7 @@ class DefaultPodWatchStrategyTest < WatchTest
           }]
         },
         status: {
+          podIP: '172.17.0.8',
           containerStatuses: [
             {
               name: 'fabric8-console-container',


### PR DESCRIPTION
This PR  adds podIP to metadata. This is helpful with correlating with access logs.