### PR TITLE
Add capability to configure a simple cache strategy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,3 +39,42 @@ task :headers do
   command_line = CopyrightHeader::CommandLine.new(args)
   command_line.execute
 end
+
+desc 'Profile the tests while running them'
+namespace :profile do
+task :test do
+  require "ruby-prof"
+  require "fileutils"
+  RubyProf.start
+  `ruby -Itest test/**/*_test.rb`
+  results = RubyProf.stop
+  # Print a flat profile to text
+  File.open "./profiler-graph.html", 'w' do |file|
+    RubyProf::GraphHtmlPrinter.new(results).print(file)
+  end
+  File.open "./profiler-stack.html", 'w' do |file|
+    printer = RubyProf::CallStackPrinter.new(results)
+    printer.print(file)
+  end
+end
+end
+
+desc 'Benchmarks the cache strategy (via tests)'
+namespace :benchmark do
+  task :cache do
+    require "benchmark"
+    Benchmark.bm do|x|
+      n = 100
+      x.report("unique caching:")  {
+        n.times do
+          `ruby -Itest test/**/test_cache_strategy.rb`
+        end
+      }
+      x.report("simple caching:") { 
+        n.times do
+          `ruby -Itest test/**/test_cache_strategy_simple.rb`
+        end
+      }
+    end
+  end
+end

--- a/lib/fluent/plugin/kubernetes_metadata_simple_cache_strategy.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_simple_cache_strategy.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module KubernetesMetadata
+  module SimpleCacheStrategy
+
+    def is_pod_cached?(pod)
+      return false if pod.nil?
+      @cache.has_key?("#{pod[:metadata][:namespace]}_#{pod[:metadata][:name]}")
+    end
+    
+    def is_namespace_cached?(namespace)
+      return false if namespace.nil?
+      @namespace_cache.has_key?("#{namespace[:metadata][:namespace]}")
+    end
+
+    def cache_pod_metadata(pod)
+      cache_key = "#{pod[:metadata][:namespace]}_#{pod[:metadata][:name]}"
+      @cache[cache_key] = parse_pod_metadata(pod)
+    end
+
+    def cache_namespace_metadata(namespace)
+        cache_key = namespace[:metadata][:uid]
+        @namespace_cache[cache_key] = parse_namespace_metadata(namespace)
+    end
+
+    def get_pod_metadata(key, namespace_name, pod_name, record_create_time, batch_miss_cache)
+      metadata = {}
+      cache_key = "#{namespace_name}_#{pod_name}"
+
+      # Do not continually hit apiserver when batch processing if we already know
+      # it will return nothing
+      if batch_miss_cache.key?(cache_key)
+        return  batch_miss_cache[cache_key]
+      end
+
+      metadata = @cache.fetch(cache_key) do
+        @stats.bump(:pod_cache_miss)
+        m = fetch_pod_metadata(namespace_name, pod_name)
+        ns_meta = @namespace_cache.fetch(namespace_name) do
+            @stats.bump(:namespace_cache_miss)
+            fetch_namespace_metadata(namespace_name)
+        end unless @skip_namespace_metadata
+        metadata = m.merge(ns_meta||{})
+        batch_miss_cache[cache_key] = metadata if m.empty?
+        metadata
+      end
+      metadata.delete_if { |_k, v| v.nil? }
+    end
+
+  end
+end

--- a/test/plugin/test_cache_strategy_simple.rb
+++ b/test/plugin/test_cache_strategy_simple.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative '../helper'
+
+class TestSimpleCacheStrategy
+
+  require_relative '../../lib/fluent/plugin/kubernetes_metadata_simple_cache_strategy'
+  include KubernetesMetadata::SimpleCacheStrategy
+
+  def initialize
+    @stats = KubernetesMetadata::Stats.new
+    @cache = LruRedux::TTL::ThreadSafeCache.new(100, 3600)
+    @namespace_cache = LruRedux::TTL::ThreadSafeCache.new(100, 3600)
+  end
+
+  attr_accessor :stats, :cache, :namespace_cache
+
+  def fetch_pod_metadata(_namespace_name, _pod_name)
+    {}
+  end
+
+  def fetch_namespace_metadata(_namespace_name)
+    {}
+  end
+
+  def log
+    logger = {}
+    def logger.trace?
+      true
+    end
+
+    def logger.trace(message)
+    end
+    logger
+  end
+end
+
+class KubernetesMetadataSimpleCacheStrategyTest < Test::Unit::TestCase
+  def setup
+    @strategy = TestSimpleCacheStrategy.new
+    @containerId = 'some_long_container_id'
+    @namespace_name = 'some_namespace_name'
+    @namespace_uuid = 'some_namespace_uuid'
+    @pod_name = 'some_pod_name'
+    @pod_uuid = 'some_pod_uuid'
+    @time = Time.now
+    @pod_meta = { 'pod_id' => @pod_uuid, 'labels' => { 'meta' => 'pod' } }
+    @namespace_meta = { 'namespace_id' => @namespace_uuid, 'creation_timestamp' => @time.to_s }
+    @batch_miss_cache = {}
+  end
+
+  test 'when cached metadata is found' do
+    exp = @pod_meta.merge(@namespace_meta)
+    exp.delete('creation_timestamp')
+    @strategy.cache["namespace_pod"] = exp
+    @strategy.namespace_cache['namespace'] = @namespace_meta
+    assert_equal(exp, @strategy.get_pod_metadata(@containerId, 'namespace', 'pod', @time, {}))
+  end
+
+  test 'when metadata is not cached and is fetched' do
+    exp = @pod_meta.merge(@namespace_meta)
+    @strategy.stub :fetch_pod_metadata, @pod_meta do
+      @strategy.stub :fetch_namespace_metadata, @namespace_meta do
+        assert_equal(exp, @strategy.get_pod_metadata(@containerId, 'namespace', 'pod', @time, {}))
+      end
+    end
+  end
+
+  test 'when metadata is not cached and pod is deleted and namespace metadata is fetched' do
+    # this is the case for a record from a deleted pod where no other
+    # records were read.
+    exp = @namespace_meta
+    @strategy.stub :fetch_pod_metadata, {} do
+      @strategy.stub :fetch_namespace_metadata, @namespace_meta do
+        assert_equal(exp, @strategy.get_pod_metadata(@containerId, 'namespace', 'pod', @time, @batch_miss_cache))
+      end
+    end
+    # assert subsequent call returns same
+    assert_equal(exp, @strategy.get_pod_metadata(@containerId, 'namespace', 'pod', @time, @batch_miss_cache))
+  end
+
+  test 'when metadata is not cached and no metadata can be fetched' do
+    # Unretrievable pod and namespace info should result in simply returning the
+    # metadata that can be gleened from the tag (namespace name, pod name, container hash)
+    @strategy.stub :fetch_pod_metadata, {} do
+      @strategy.stub :fetch_namespace_metadata, {} do
+        assert_equal({}, @strategy.get_pod_metadata(@containerId, 'aNamespace', 'aPod', @time, @batch_miss_cache))
+      end
+    end
+    # assert subsequent call returns same
+    assert_equal({}, @strategy.get_pod_metadata(@containerId, 'aNamespace', 'aPod', @time, @batch_miss_cache))
+  end
+end

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -34,10 +34,27 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
     Test::Driver::Filter.new(Plugin::KubernetesMetadataFilter).configure(conf)
   end
 
+  sub_test_case 'configure cache_strategy' do
+    test 'simple' do
+      d = create_driver('
+        cache_strategy simple
+      ')
+      assert_equal(:simple, d.instance.cache_strategy)
+    end
+    
+    test 'unique' do
+      d = create_driver('
+        cache_strategy unique
+      ')
+      assert_equal(:unique, d.instance.cache_strategy)
+    end
+  end
+
   sub_test_case 'configure' do
     test 'check default' do
       d = create_driver
       assert_equal(1000, d.instance.cache_size)
+      assert_equal(:unique, d.instance.cache_strategy)
     end
 
     test 'kubernetes url' do


### PR DESCRIPTION
This PR introduces configuration capability to configure a simple caching strategy:
* Makes no effort to try to provide labels from deleted pods which no longer exist

cc @eranra this would be worth to build into an image and run through the benchmarks