### PR TITLE
Allow configuring client API adapter for testing

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -85,6 +85,11 @@ module Fluent::Plugin
     config_param :skip_container_metadata, :bool, default: false
     config_param :skip_master_url, :bool, default: false
     config_param :skip_namespace_metadata, :bool, default: false
+
+    # A classname in the form of Test::APIAdapter which will try
+    # to be resolved from a relative named file 'test_api_adapter'
+    config_param :test_api_adapter, :string, default: nil
+
     # The time interval in seconds for retry backoffs when watch connections fail.
     config_param :watch_retry_interval, :integer, default: 1
     # The base number of exponential backoff for retries.
@@ -245,6 +250,12 @@ module Fluent::Plugin
           auth_options: auth_options,
           as: :parsed_symbolized
         )
+
+        if @test_api_adapter
+          log.info "Extending client with test api adaper #{@test_api_adapter}"
+          require_relative @test_api_adapter.underscore
+          @client.extend(eval(@test_api_adapter))
+        end
 
         begin
           @client.api_valid?

--- a/lib/fluent/plugin/kubernetes_metadata_test_api_adapter.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_test_api_adapter.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#
+# Fluentd Kubernetes Metadata Filter Plugin - Enrich Fluentd events with
+# Kubernetes metadata
+#
+# Copyright 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'kubeclient'
+
+module KubernetesMetadata
+    module TestApiAdapter
+      
+      def api_valid?
+        true
+      end
+      def get_namespace(namespace_name)
+        return {
+          metadata: {
+            name: namespace_name,
+            uid: namespace_name + 'uuid',
+            labels: {
+              foo_ns: 'bar_ns'
+            }
+          }
+        }
+      end
+
+      def get_pod(pod_name, namespace_name)
+        return {
+          metadata: {
+            name: pod_name,
+            namespace: namespace_name,
+            uid: namespace_name + namespace_name + "uuid",
+            labels: {
+              foo: 'bar'
+            }
+          },
+          spec: {
+            nodeName: 'aNodeName',
+            containers: [{
+              name: 'foo',
+              image: 'bar'
+            }, {
+              name: 'bar',
+              image: 'foo'
+            }]
+          },
+          status: {
+            podIP: '172.17.0.8'
+          }
+        }
+      end
+
+    end
+end

--- a/lib/fluent/plugin/kubernetes_metadata_util.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_util.rb
@@ -38,3 +38,16 @@ module KubernetesMetadata
     end
   end
 end
+
+#https://stackoverflow.com/questions/5622435/how-do-i-convert-a-ruby-class-name-to-a-underscore-delimited-symbol
+class String
+  def underscore
+    word = self.dup
+    word.gsub!(/::/, '_')
+    word.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+    word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+    word.tr!("-", "_")
+    word.downcase!
+    word
+  end
+end


### PR DESCRIPTION
This PR:

* Allows overriding configuration of API client to allow testing outside a kubernetes cluster with mocked responses