### PR TITLE
chore(gems): upgrade fluentd to allow v1.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-kubernetes_metadata_filter (2.7.0)
-      fluentd (>= 0.14.0, < 1.13)
+      fluentd (>= 0.14.0, < 1.14)
       kubeclient (< 5)
       lru_redux
 
@@ -26,11 +26,11 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     escape_utils (1.2.1)
-    ffi (1.15.0)
+    ffi (1.15.1)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.12.3)
+    fluentd (1.13.0)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -62,7 +62,7 @@ GEM
     http_parser.rb (0.6.0)
     jsonpath (1.1.0)
       multi_json
-    kubeclient (4.9.1)
+    kubeclient (4.9.2)
       http (>= 3.0, < 5.0)
       jsonpath (~> 1.0)
       recursive-open-struct (~> 1.1, >= 1.1.1)
@@ -105,7 +105,7 @@ GEM
       parser (>= 2.7.1.5)
     ruby-progressbar (1.11.0)
     rugged (1.1.0)
-    serverengine (2.2.3)
+    serverengine (2.2.4)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     simplecov (0.21.2)
@@ -155,4 +155,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.1.4
+   2.2.19

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5.0'
 
-  gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.13']
+  gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.14']
   gem.add_runtime_dependency 'kubeclient', '< 5'
   gem.add_runtime_dependency 'lru_redux'
 


### PR DESCRIPTION
 - add up to v1.14 fluentd gem
 - fluentd [v1.13.0 changelog](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1130---20210529)

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>