### PR TITLE
fix #302.  Allow plugin to use fluentd v1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ missingdeps: &missingdeps
             cat /etc/os-release
             printf "deb http://deb.debian.org/debian buster main\ndeb http://security.debian.org buster/updates main\ndeb-src http://security.debian.org buster/updates main" > /tmp/sources.list
             sudo cp /tmp/sources.list /etc/apt/sources.list
-            sudo apt-get update
+            sudo apt-get --allow-releaseinfo-change update
             sudo apt-get install cmake libicu-dev libssl-dev
 
 test: &test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fluent-plugin-kubernetes_metadata_filter (2.7.2)
+    fluent-plugin-kubernetes_metadata_filter (2.8.0)
       fluentd (>= 0.14.0, < 1.15)
       kubeclient (< 5)
       lru_redux
@@ -30,7 +30,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.13.2)
+    fluentd (1.14.0)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-kubernetes_metadata_filter (2.7.2)
-      fluentd (>= 0.14.0, < 1.14)
+      fluentd (>= 0.14.0, < 1.15)
       kubeclient (< 5)
       lru_redux
 

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5.0'
 
-  gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.14']
+  gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.15']
   gem.add_runtime_dependency 'kubeclient', '< 5'
   gem.add_runtime_dependency 'lru_redux'
 

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = 'fluent-plugin-kubernetes_metadata_filter'
-  gem.version       = '2.7.2'
+  gem.version       = '2.8.0'
   gem.authors       = ['Jimmi Dyson']
   gem.email         = ['jimmidyson@gmail.com']
   gem.description   = 'Filter plugin to add Kubernetes metadata'


### PR DESCRIPTION
This PR
* fixes #302 

By updating the gemspec to allow installation with v1.14