### PR TITLE
fix #295. Fix min/max version of kubeclient dep

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     fluent-plugin-kubernetes_metadata_filter (2.8.0)
       fluentd (>= 0.14.0, < 1.15)
-      kubeclient (< 5)
+      kubeclient (>= 4.0.0, < 5.0.0)
       lru_redux
 
 GEM

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.5.0'
 
   gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.15']
-  gem.add_runtime_dependency 'kubeclient', '< 5'
+  gem.add_runtime_dependency 'kubeclient', ['>= 4.0.0', '< 5.0.0']
   gem.add_runtime_dependency 'lru_redux'
 
   gem.add_development_dependency 'bump'


### PR DESCRIPTION


Supersedes https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/295 to limit kube client version