### PR TITLE
fix #294. Output error  for parsing container meta as a warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fluent-plugin-kubernetes_metadata_filter (2.8.0)
+    fluent-plugin-kubernetes_metadata_filter (2.8.1)
       fluentd (>= 0.14.0, < 1.15)
       kubeclient (>= 4.0.0, < 5.0.0)
       lru_redux
@@ -26,7 +26,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     escape_utils (1.2.1)
-    ffi (1.15.3)
+    ffi (1.15.4)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -70,7 +70,7 @@ GEM
     lru_redux (1.1.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0704)
+    mime-types-data (3.2021.0901)
     mini_mime (1.0.2)
     minitest (4.7.5)
     msgpack (1.4.2)
@@ -126,7 +126,7 @@ GEM
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.7)
+    unf_ext (0.0.8)
     unicode-display_width (2.0.0)
     vcr (6.0.0)
     webmock (3.11.1)

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = 'fluent-plugin-kubernetes_metadata_filter'
-  gem.version       = '2.8.0'
+  gem.version       = '2.8.1'
   gem.authors       = ['Jimmi Dyson']
   gem.email         = ['jimmidyson@gmail.com']
   gem.description   = 'Filter plugin to add Kubernetes metadata'

--- a/lib/fluent/plugin/kubernetes_metadata_common.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_common.rb
@@ -84,8 +84,8 @@ module KubernetesMetadata
                                            }
                                          end
         end
-      rescue StandardError
-        log.debug("parsing container meta information failed for: #{pod_object[:metadata][:namespace]}/#{pod_object[:metadata][:name]} ")
+      rescue StandardError=>e
+        log.warn("parsing container meta information failed for: #{pod_object[:metadata][:namespace]}/#{pod_object[:metadata][:name]}: #{e}")
       end
 
       kubernetes_metadata = {

--- a/test/plugin/watch_test.rb
+++ b/test/plugin/watch_test.rb
@@ -69,6 +69,8 @@ class WatchTest < Test::Unit::TestCase
 
     def logger.error(message, error)
     end
+    def logger.warn(message)
+    end
     logger
   end
 end


### PR DESCRIPTION
This PR fixes #294 to log as a warning why container metadata was not parsable