### PR TITLE
fix #105: Modify to fix collection from /var/log/pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ payload.  The following configuration options are removed:
 
 One way of preserving JSON logs can be through the [parser plugin](https://docs.fluentd.org/filter/parser)
 
-**NOTE** As of this release, the use of `use_journal` is **DEPRECATED**.  If this setting is not present, the plugin will
+**NOTE** As of release v2.1.4, the use of `use_journal` is **DEPRECATED**.  If this setting is not present, the plugin will
 attempt to figure out the source of the metadata fields from the following:
 - If `lookup_from_k8s_field true` (the default) and the following fields are present in the record:
 `docker.container_id`, `kubernetes.namespace_name`, `kubernetes.pod_name`, `kubernetes.container_name`,

--- a/lib/fluent/plugin/kubernetes_metadata_cache_strategy.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_cache_strategy.rb
@@ -24,8 +24,6 @@ module KubernetesMetadata
       metadata = {}
       ids = @id_cache[key]
       if ids.nil?
-        # FAST PATH
-        # Cache hit, fetch metadata from the cache
         @stats.bump(:id_cache_miss)
         return batch_miss_cache["#{namespace_name}_#{pod_name}"] if batch_miss_cache.key?("#{namespace_name}_#{pod_name}")
 
@@ -65,7 +63,7 @@ module KubernetesMetadata
               @stats.bump(:id_cache_orphaned_record)
             end
             if @allow_orphans
-              log.trace("orphaning message for: #{namespace_name}/#{pod_name} ") if log.trace?
+              log.trace("orphaning message for: #{namespace_name}/#{pod_name} ")
               metadata = {
                 'orphaned_namespace' => namespace_name,
                 'namespace_name' => @orphaned_namespace_name,

--- a/lib/fluent/plugin/kubernetes_metadata_common.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_common.rb
@@ -78,9 +78,9 @@ module KubernetesMetadata
       container_meta = {}
       begin
         pod_object[:status][:containerStatuses].each do |container_status|
-          # get plain container id (eg. docker://hash -> hash)
-          container_id = container_status[:containerID] ? container_status[:containerID].sub(%r{^[-_a-zA-Z0-9]+://}, '') : container_status[:name]
-          container_meta[container_id] = if @skip_container_metadata
+          container_id = (container_status[:containerID]||"").sub(%r{^[-_a-zA-Z0-9]+://}, '')
+          key = container_status[:name]
+          container_meta[key] = if @skip_container_metadata
                                            {
                                              'name' => container_status[:name]
                                            }
@@ -88,7 +88,8 @@ module KubernetesMetadata
                                            {
                                              'name' => container_status[:name],
                                              'image' => container_status[:image],
-                                             'image_id' => container_status[:imageID]
+                                             'image_id' => container_status[:imageID],
+                                             :containerID => container_id
                                            }
                                          end
         end if pod_object[:status] && pod_object[:status][:containerStatuses]

--- a/test/plugin/test_cache_strategy.rb
+++ b/test/plugin/test_cache_strategy.rb
@@ -44,7 +44,7 @@ class TestCacheStrategy
 
   def log
     logger = {}
-    def logger.trace?
+    def logger.on_trace
       true
     end
 


### PR DESCRIPTION
This PR:
* fixes #105
* Fixes logs that are collected from /var/log/pods
* Adjusts the tests to account for the fact the container hash is not available in the tag
* Adds parameter 'tag_format' to default a known tag pattern

cc @vimalk78 @alanconway 