### PR TITLE
prep for dependency upon ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,6 @@ test: &test
   command: bundle exec rake test --trace
 
 executors:
-  ruby-2-5:
-    docker:
-      - image: circleci/ruby:2.5.5
   ruby-2-6:
     docker:
       - image: circleci/ruby:2.6.3
@@ -50,8 +47,6 @@ jobs:
 workflows:
   "test_multiple_ruby_versions":
     jobs:
-      - ruby-test:
-          ruby-version: ruby-2-5
       - ruby-test:
           ruby-version: ruby-2-6
       - ruby-test:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fluent-plugin-kubernetes_metadata_filter (2.9.5)
+    fluent-plugin-kubernetes_metadata_filter (2.10.0)
       fluentd (>= 0.14.0, < 1.15)
       kubeclient (>= 4.0.0, < 5.0.0)
       lru_redux
@@ -16,7 +16,7 @@ GEM
     charlock_holmes (0.7.7)
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cool.io (1.7.1)
     copyright-header (1.0.22)
       github-linguist
@@ -30,7 +30,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.14.5)
+    fluentd (1.14.6)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
@@ -73,7 +73,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     minitest (4.7.5)
-    msgpack (1.4.5)
+    msgpack (1.5.1)
     multi_json (1.15.0)
     netrc (0.11.0)
     parallel (1.21.0)
@@ -122,7 +122,7 @@ GEM
       test-unit (>= 2.5.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.5)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ that rely on the authenticity of the namespace for proper log isolation.
 
 | fluent-plugin-kubernetes_metadata_filter  | fluentd | ruby |
 |-------------------|---------|------|
+| >= 2.10.0 | >= v1.10.0 | >= 2.6 |
 | >= 2.5.0 | >= v1.10.0 | >= 2.5 |
 | >= 2.0.0 | >= v0.14.20 | >= 2.1 |
 |  < 2.0.0 | >= v0.12.0 | >= 1.9 |

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -5,9 +5,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = 'fluent-plugin-kubernetes_metadata_filter'
-  gem.version       = '2.9.5'
-  gem.authors       = ['Jimmi Dyson']
-  gem.email         = ['jimmidyson@gmail.com']
+  gem.version       = '2.10.0'
+  gem.authors       = ['OpenShift Cluster Logging','Jimmi Dyson']
+  gem.email         = ['team-logging@redhat.com','jimmidyson@gmail.com']
   gem.description   = 'Filter plugin to add Kubernetes metadata'
   gem.summary       = 'Fluentd filter plugin to add Kubernetes metadata'
   gem.homepage      = 'https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter'


### PR DESCRIPTION
This PR:
* preps the repo for dependency upon ruby 2.6 or better to unblock https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/329