### PR TITLE
Reduce kubeclient timeouts to reasonable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ when true (default: `true`)
 * `skip_namespace_metadata` - Skip the namespace_id field from the metadata. The fetch_namespace_metadata function will be skipped. The plugin will be faster and cpu consumption will be less.
 * `stats_interval` - The interval to display cache stats (default: 30s).  Set to 0 to disable stats collection and logging
 * `watch_retry_interval` - The time interval in seconds for retry backoffs when watch connections fail. (default: `10`)
+* `open_timeout` - The time in seconds to wait for a connection to kubernetes service. (default: `3`)
+* `read_timeout` - The time in seconds to wait for a read from kubernetes service. (default: `10`)
 
 
 Reading from a JSON formatted log files with `in_tail` and wildcard filenames while respecting the CRI-o log format with the same config you need the fluent-plugin "multi-format-parser":

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -50,6 +50,8 @@ module Fluent::Plugin
     config_param :client_key, :string, default: nil
     config_param :ca_file, :string, default: nil
     config_param :verify_ssl, :bool, default: true
+    config_param :open_timeout, :integer, default: 3
+    config_param :read_timeout, :integer, default: 10
 
     REGEX_VAR_LOG_PODS = '(var\.log\.pods)\.(?<namespace>[^_]+)_(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<pod_uuid>[a-z0-9-]*)\.(?<container_name>.+)\..*\.log$'
     REGEX_VAR_LOG_CONTAINERS = '(var\.log\.containers)\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
@@ -299,6 +301,10 @@ module Fluent::Plugin
         @apiVersion,
         ssl_options: @ssl_options,
         auth_options: @auth_options,
+        timeouts: {
+          open: @open_timeout,
+          read: @read_timeout
+        },
         as: :parsed_symbolized
       )
     end


### PR DESCRIPTION
The API should be very responsive. If it hangs, it is usually because
something is wrong, and waiting longer won't help.