### PR TITLE
pod watcher must reinitialize on 401

### DIFF
--- a/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_watch_pods.rb
@@ -52,7 +52,7 @@ module KubernetesMetadata
           # recreate client to refresh token
           log.info("Encountered '401 Unauthorized' exception in watch, recreating client to refresh token")
           create_client()
-          namespace_watcher = nil
+          pod_watcher = nil
         else
           # treat all other errors the same as StandardError, log, swallow and reset
           @stats.bump(:pod_watch_failures)


### PR DESCRIPTION
The unauthorized error handling added in https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/337 correctly handles re-initializing the namespace watcher, but a dangling reference to it was left in the pod watcher causing it to infinitely loop with an expired client.