### PR TITLE
LOG-3046: clone meta so the ref can't be modified for subsequent records

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -331,6 +331,11 @@ module Fluent::Plugin
         metadata['kubernetes'].merge!(pod_metadata) if pod_metadata
         metadata['kubernetes'].delete('containers')
       end
+      metadata['kubernetes'].tap do |kube|
+        kube.each_pair do |k,v|
+          kube[k.dup] = v.dup
+        end
+      end
       metadata.delete('docker') if metadata['docker'] && (metadata['docker']['container_id'].nil? || metadata['docker']['container_id'].empty?)
       metadata
     end


### PR DESCRIPTION
This PR:
* dups  the meta for cases where it gets modified in processing and we dont want  it to affect future filtering

ref: https://issues.redhat.com/browse/LOG-3046

cc @cahartma