### PR TITLE
Reduce log level for missing pod error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    power_assert (2.0.1)
+    power_assert (2.0.2)
     public_suffix (4.0.7)
     rainbow (3.1.1)
     rake (13.0.6)
@@ -115,7 +115,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     strptime (0.2.5)
-    test-unit (3.0.9)
+    test-unit (3.5.5)
       power_assert
     test-unit-rr (1.0.5)
       rr (>= 1.1.1)
@@ -148,7 +148,7 @@ DEPENDENCIES
   minitest (~> 4.0)
   rake
   rubocop
-  test-unit (~> 3.0.2)
+  test-unit (~> 3.5.5)
   test-unit-rr (~> 1.0.3)
   vcr
   webmock

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'copyright-header'
   gem.add_development_dependency 'minitest', '~> 4.0'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'test-unit', '~> 3.0.2'
+  gem.add_development_dependency 'test-unit', '~> 3.5.5'
   gem.add_development_dependency 'test-unit-rr', '~> 1.0.3'
   gem.add_development_dependency 'vcr'
   gem.add_development_dependency 'webmock'

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -108,6 +108,9 @@ module Fluent::Plugin
           # recreate client to refresh token
           log.info("Encountered '401 Unauthorized' exception, recreating client to refresh token")
           create_client()
+        elsif e.error_code == 404
+          log.debug "Encountered '404 Not Found' exception, pod not found"
+          @stats.bump(:pod_cache_api_nil_error)
         else
           log.error "Exception '#{e}' encountered fetching pod metadata from Kubernetes API #{@apiVersion} endpoint #{@kubernetes_url}"
           @stats.bump(:pod_cache_api_nil_error)


### PR DESCRIPTION
It is not uncommon for a pod to be gone by the time logs are processed, so reduce the log level appropriately. This avoids emitting spurious error messages for harmless events.

The log level for this kind of API error was `debug` in v2, but was increased to `error` in [this PR](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/337/files#diff-0b4b9044f59b6776e7937e8f714cb59db8858c728efb76dd18456f026f423f19R127) which made it into v3. So this change just reverts the logging behaviour back to what it was in v2.