### PR TITLE
update Gemfile.lock for v2.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.15.0)
+    fluentd (1.15.3)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)


### PR DESCRIPTION
Please consider updating gemfile.lock for v2.13.0
https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/363