### PR TITLE
Improve pod and namespace label management

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ when true (default: `true`)
   to trust the intermediate CA certs we do have, set this to `true` - this corresponds to
   the `openssl s_client -partial_chain` flag and `X509_V_FLAG_PARTIAL_CHAIN` (default: `false`)
 * `skip_labels` - Skip all label fields from the metadata.
+* `skip_pod_labels` - Skip only pod label fields from the metadata.
+* `skip_namespace_labels` - Skip only namespace label fields from the metadata.
 * `skip_container_metadata` - Skip some of the container data of the metadata. The metadata will not contain the container_image and container_image_id fields.
 * `skip_master_url` - Skip the master_url field from the metadata.
 * `skip_namespace_metadata` - Skip the namespace_id field from the metadata. The fetch_namespace_metadata function will be skipped. The plugin will be faster and cpu consumption will be less.

--- a/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -77,6 +77,8 @@ module Fluent::Plugin
     # the openssl s_client -partial_chain flag and X509_V_FLAG_PARTIAL_CHAIN
     config_param :ssl_partial_chain, :bool, default: false
     config_param :skip_labels, :bool, default: false
+    config_param :skip_pod_labels, :bool, default: false
+    config_param :skip_namespace_labels, :bool, default: false
     config_param :skip_container_metadata, :bool, default: false
     config_param :skip_master_url, :bool, default: false
     config_param :skip_namespace_metadata, :bool, default: false
@@ -198,7 +200,7 @@ module Fluent::Plugin
       @namespace_cache = LruRedux::TTL::ThreadSafeCache.new(@cache_size, @cache_ttl)
 
       @tag_to_kubernetes_name_regexp_compiled = Regexp.compile(@tag_to_kubernetes_name_regexp)
-      
+
       # Use Kubernetes default service account if we're in a pod.
       if @kubernetes_url.nil?
         log.debug 'Kubernetes URL is not set - inspecting environ'
@@ -351,7 +353,7 @@ module Fluent::Plugin
           tag_match_data['pod_uuid']
         else
           tag_match_data['docker_id']
-        end 
+        end
         docker_id = tag_match_data.names.include?('docker_id') ? tag_match_data['docker_id'] : nil
         metadata = get_metadata_for_record(tag_match_data['namespace'], tag_match_data['pod_name'], tag_match_data['container_name'],
                                                 cache_key, time, batch_miss_cache, docker_id)

--- a/lib/fluent/plugin/kubernetes_metadata_common.rb
+++ b/lib/fluent/plugin/kubernetes_metadata_common.rb
@@ -40,7 +40,7 @@ module KubernetesMetadata
 
     def parse_namespace_metadata(namespace_object)
       labels = ''
-      labels = syms_to_strs(namespace_object[:metadata][:labels].to_h) unless @skip_labels
+      labels = syms_to_strs(namespace_object[:metadata][:labels].to_h) unless (@skip_labels || @skip_namespace_labels)
 
       annotations = match_annotations(syms_to_strs(namespace_object[:metadata][:annotations].to_h))
 
@@ -55,7 +55,7 @@ module KubernetesMetadata
 
     def parse_pod_metadata(pod_object)
       labels = ''
-      labels = syms_to_strs(pod_object[:metadata][:labels].to_h) unless @skip_labels
+      labels = syms_to_strs(pod_object[:metadata][:labels].to_h) unless (@skip_labels || @skip_pod_labels)
 
       annotations = match_annotations(syms_to_strs(pod_object[:metadata][:annotations].to_h))
 

--- a/test/cassettes/kubernetes_get_namespace_default.yml
+++ b/test/cassettes/kubernetes_get_namespace_default.yml
@@ -53,7 +53,10 @@ http_interactions:
             "selfLink": "/api/v1/namespaces/default",
             "uid": "898268c8-4a36-11e5-9d81-42010af0194c",
             "resourceVersion": "6",
-            "creationTimestamp": "2015-05-08T09:22:01Z"
+            "creationTimestamp": "2015-05-08T09:22:01Z",
+            "labels": {
+              "tenant": "test"
+            }
           },
           "spec": {
             "finalizers": [

--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -49,7 +49,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
         d.instance.dump_stats
         assert_false(d.instance.instance_variable_get("@curr_time").nil?)
       end
-      
+
       test 'disables stats when <= zero' do
         d = create_driver('stats_interval 0')
         assert_equal(0, d.instance.stats_interval)
@@ -199,6 +199,9 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'pod_name' => 'fabric8-console-controller-98rqc',
               'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
               'namespace_name' => 'default',
+              'namespace_labels' => {
+                'tenant' => 'test'
+              },
               'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
               'pod_ip' => '172.17.0.8',
               'master_url' => 'https://localhost:8443',
@@ -231,6 +234,9 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
               'pod_name' => 'fabric8-console-controller-98rqc',
               'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
               'namespace_name' => 'default',
+              'namespace_labels' => {
+                'tenant' => 'test'
+              },
               'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
               'pod_ip' => '172.17.0.8',
               'master_url' => 'https://localhost:8443',
@@ -330,6 +336,9 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'namespace_labels' => {
+              'tenant' => 'test'
+            },
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
             'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
@@ -360,6 +369,9 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'namespace_labels' => {
+              'tenant' => 'test'
+            },
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
             'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
@@ -410,6 +422,9 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'namespace_labels' => {
+              'tenant' => 'test'
+            },
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
             'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
@@ -585,8 +600,8 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'host' => 'jimmi-redhat.localnet',
             'pod_name' => 'fabric8-console-controller-98rqc',
             'container_name' => 'fabric8-console-container',
-            'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'namespace_name' => 'default',
+            'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'container_image' => 'fabric8/hawtio-kubernetes:latest',
             'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
@@ -628,8 +643,8 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'container_name' => 'fabric8-console-container',
             'container_image' => 'fabric8/hawtio-kubernetes:latest',
             'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
-            'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'namespace_name' => 'default',
+            'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
             'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
@@ -643,7 +658,7 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
     end
 
     test 'processes all events when reading from MessagePackEventStream' do
-      VCR.use_cassettes([{ name: 'valid_kubernetes_api_server' }, 
+      VCR.use_cassettes([{ name: 'valid_kubernetes_api_server' },
                          { name: 'kubernetes_get_api_v1' },
                          { name: 'kubernetes_get_pod' },
                          { name: 'kubernetes_get_namespace_default' }]) do
@@ -675,6 +690,9 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
             'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
             'namespace_name' => 'default',
             'namespace_id' => '898268c8-4a36-11e5-9d81-42010af0194c',
+            'namespace_labels' => {
+              'tenant' => 'test'
+            },
             'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
             'pod_ip' => '172.17.0.8',
             'master_url' => 'https://localhost:8443',
@@ -718,5 +736,75 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
         assert_equal(expected_kube_metadata, filtered[0])
       end
     end
+
+    test 'with docker & kubernetes metadata using skip namespace labels config param' do
+      VCR.use_cassettes([{ name: 'valid_kubernetes_api_server' }, { name: 'kubernetes_get_api_v1' }, { name: 'kubernetes_get_pod' },
+                         { name: 'kubernetes_get_namespace_default' }]) do
+        filtered = emit({}, '
+          kubernetes_url https://localhost:8443
+          watch false
+          cache_size 1
+          stats_interval 0
+          skip_namespace_labels true
+          skip_master_url true
+        ')
+        expected_kube_metadata = {
+          'docker'=>{
+            'container_id'=>'49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
+          },
+          'kubernetes' => {
+            'host' => 'jimmi-redhat.localnet',
+            'pod_name' => 'fabric8-console-controller-98rqc',
+            'container_name' => 'fabric8-console-container',
+            'container_image' => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_name' => 'default',
+            "namespace_id"=>"898268c8-4a36-11e5-9d81-42010af0194c",
+            'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
+            'labels' => {
+              'component' => 'fabric8Console'
+            }
+          }
+        }
+
+        assert_equal(expected_kube_metadata, filtered[0])
+      end
+    end
+    test 'with docker & kubernetes metadata using skip pod labels config param' do
+      VCR.use_cassettes([{ name: 'valid_kubernetes_api_server' }, { name: 'kubernetes_get_api_v1' }, { name: 'kubernetes_get_pod' },
+                         { name: 'kubernetes_get_namespace_default' }]) do
+        filtered = emit({}, '
+          kubernetes_url https://localhost:8443
+          watch false
+          cache_size 1
+          stats_interval 0
+          skip_pod_labels true
+          skip_master_url true
+        ')
+        expected_kube_metadata = {
+          'docker'=>{
+            'container_id'=>'49095a2894da899d3b327c5fde1e056a81376cc9a8f8b09a195f2a92bceed459'
+          },
+          'kubernetes' => {
+            'host' => 'jimmi-redhat.localnet',
+            'pod_name' => 'fabric8-console-controller-98rqc',
+            'container_name' => 'fabric8-console-container',
+            'container_image' => 'fabric8/hawtio-kubernetes:latest',
+            'container_image_id' => 'docker://b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303',
+            'namespace_name' => 'default',
+            "namespace_id"=>"898268c8-4a36-11e5-9d81-42010af0194c",
+            'namespace_labels' => {
+              'tenant' => 'test'
+            },
+            'pod_id' => 'c76927af-f563-11e4-b32d-54ee7527188d',
+            'pod_ip' => '172.17.0.8',
+          }
+        }
+
+        assert_equal(expected_kube_metadata, filtered[0])
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hi!

Currently, the plugin allows to obtain labels from the pods and the namespaces or exclusively the ones from the pods (if I use the parameter skip_namespace_metadata: true and skip_labels: false).
In multi-tenant scenarios, we may need namespace labels to be able to assign each event to its tenant and, with the current configuration options, the only way to get these labels is by getting the ones from the pods too. In an average cluster, i think it is more likely that the labels of the pods may not be standardized and therefore we have too many. 

The idea of ​​this PR is to allow to choose between the labels from the pod or from the namespace, and that you don't always have to get both.

Please let me know what do you think about this feature or if i'm missing something. If you consider this is a good idea, I'll continue working on the PR to implement tests and any other suggestion you have (first time with ruby, so keep that in mind ;) )

Thanks!



