### PR TITLE
Allow use of Fluentd v1.18.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-kubernetes_metadata_filter (3.5.1)
-      fluentd (>= 0.14.0, < 1.18)
+      fluentd (>= 0.14.0, < 1.19)
       kubeclient (>= 4.0.0, < 5.0.0)
       lru_redux
 

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.7.0'
 
-  gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.18']
+  gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.19']
   gem.add_runtime_dependency 'kubeclient', ['>= 4.0.0', '< 5.0.0']
   gem.add_runtime_dependency 'lru_redux'
 


### PR DESCRIPTION
v1.18.0 has been released.

https://github.com/fluent/fluentd/releases/tag/v1.18.0
