### PR TITLE
Allow use of fluentd 1.18.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fluent-plugin-kubernetes_metadata_filter (3.5.2)
+    fluent-plugin-kubernetes_metadata_filter (3.6.0)
       fluentd (>= 0.14.0, < 1.19)
       kubeclient (>= 4.0.0, < 5.0.0)
       lru_redux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-kubernetes_metadata_filter (3.5.2)
-      fluentd (>= 0.14.0, < 1.18)
+      fluentd (>= 0.14.0, < 1.19)
       kubeclient (>= 4.0.0, < 5.0.0)
       lru_redux
 
@@ -32,7 +32,7 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
-    fluentd (1.17.1)
+    fluentd (1.18.0)
       base64 (~> 0.2)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
@@ -139,7 +139,8 @@ GEM
     tzinfo-data (1.2024.2)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.2.0)
-    vcr (6.0.0)
+    vcr (6.3.1)
+      base64
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.7.0'
 
-  gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.18']
+  gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.19']
   gem.add_runtime_dependency 'kubeclient', ['>= 4.0.0', '< 5.0.0']
   gem.add_runtime_dependency 'lru_redux'
 

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = 'fluent-plugin-kubernetes_metadata_filter'
-  gem.version       = '3.5.2'
+  gem.version       = '3.6.0'
   gem.authors       = ['OpenShift Cluster Logging','Jimmi Dyson']
   gem.email         = ['team-logging@redhat.com','jimmidyson@gmail.com']
   gem.description   = 'Filter plugin to add Kubernetes metadata'


### PR DESCRIPTION
This PR:
* Expands the max fluentd version to include 1.18.x
* Updates the vcr gem for testing to v6.3.1 to resolve too many args issue

Ran unit tests using:
* ruby v2.7.5
* ruby v3.1.0