### PR TITLE
CI: Use latest Bundler to support Ruby head

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,3 @@ DEPENDENCIES
   vcr
   webmock
   yajl-ruby
-
-BUNDLED WITH
-   2.4.22


### PR DESCRIPTION
Ruby 4.1.0dev (head) removed `Pathname::SEPARATOR_PAT`, which caused Bundler 2.4.22 (specified in Gemfile.lock) to fail with a `NameError`.

```
NameError: private constant Pathname::SEPARATOR_PAT referenced
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/source/path.rb:228:in 'block in Bundler::Source::Path#generate_bin'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/source/path.rb:227:in 'Array#map'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/source/path.rb:227:in 'Bundler::Source::Path#generate_bin'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/source/path.rb:88:in 'Bundler::Source::Path#install'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/installer/gem_installer.rb:54:in 'Bundler::GemInstaller#install'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/installer/gem_installer.rb:16:in 'Bundler::GemInstaller#install_from_spec'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/installer/parallel_installer.rb:130:in 'Bundler::ParallelInstaller#do_install'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/installer/parallel_installer.rb:121:in 'block in Bundler::ParallelInstaller#worker_pool'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/worker.rb:62:in 'Bundler::Worker#apply_func'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/worker.rb:57:in 'block in Bundler::Worker#process_queue'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/worker.rb:54:in 'Kernel#loop'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/worker.rb:54:in 'Bundler::Worker#process_queue'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/4.1.0+1/gems/bundler-2.4.22/lib/bundler/worker.rb:90:in 'block (2 levels) in Bundler::Worker#create_threads'

```
Ref. https://github.com/fluent-plugins-nursery/fluent-plugin-kubernetes_metadata_filter/actions/runs/25237069015


By removing `BUNDLED WITH`, setup-ruby will use a version of Bundler compatible with the running Ruby version, resolving the incompatibility in the head build while maintaining Ruby 2.7 support.