### PR TITLE
Remove unused yajl dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'rubocop-rake'
 gem 'test-unit'
 gem 'vcr'
 gem 'webmock'
-gem 'yajl-ruby'
 
 # Specify your gem's dependencies in fluent-plugin-add.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,4 +179,3 @@ DEPENDENCIES
   test-unit
   vcr
   webmock
-  yajl-ruby


### PR DESCRIPTION
Since the yajl-ruby gem depends on a deprecated Ruby C API, it cannot be installed with Ruby 4.1.