### PR TITLE
gem: remove copyright-header to bypass charlock_holmes build failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 gem 'bump'
 gem 'bundler'
 gem 'codeclimate-test-reporter', '< 1.0.0', require: false
-gem 'copyright-header'
 gem 'minitest', '~> 5.0' # minitest/mock was removed in minitest 6.0, so we need to use minitest 5.x for now
 gem 'rake'
 gem 'rubocop'

--- a/Rakefile
+++ b/Rakefile
@@ -19,22 +19,3 @@ Rake::TestTask.new(:base_test) do |task|
   task.pattern = 'test/**/test_*.rb'
   task.warning = false
 end
-
-desc 'Add copyright headers'
-task :headers do
-  require 'rubygems'
-  require 'copyright_header'
-
-  args = {
-    license: 'Apache-2.0',
-    copyright_software: 'Fluentd Kubernetes Metadata Filter Plugin',
-    copyright_software_description: 'Enrich Fluentd events with Kubernetes metadata',
-    copyright_holders: ['Red Hat, Inc.'],
-    copyright_years: ['2015-2021'],
-    add_path: 'lib:test',
-    output_dir: '.'
-  }
-
-  command_line = CopyrightHeader::CommandLine.new(args)
-  command_line.execute
-end


### PR DESCRIPTION
`charlock_holmes` (0.7.9) fails to build its native extension on environments with GCC 16.1.1 and ICU 78 due to C++ compatibility issues.

Since [`copyright-header`](https://github.com/cloudposse-archives/copyright-header) is a development utility used for inserting copyright notices into source files, removing it has no impact on the core functionality of the application.

This change unblocks `bundle update` on modern environments by removing the dependency chain: copyright-header -> github-linguist -> charlock_holmes.

```
$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Local specification for fluentd-1.19.0 has different dependencies than the remote gem, ignoring it
Resolving dependencies...
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      psych (>= 4.0.0)
      Available/installed versions of this gem:
      - 5.4.0
      - 5.3.1
      - 5.2.6
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
Installing charlock_holmes 0.7.9 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/watson/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/charlock_holmes-0.7.9/ext/charlock_holmes
/home/watson/.rbenv/versions/4.0.5/bin/ruby extconf.rb
checking for pkg-config for icu-i18n... [" ", "", "-licui18n"]
checking for pkg-config for icu-io... [" ", "", "-licuio"]
checking for pkg-config for icu-uc... [" ", "", "-licuuc"]
checking for -licui18n... yes
checking for unicode/ucnv.h... yes
checking for -lz... yes
checking for -licuuc... yes
checking for -licudata... yes
checking for icu that requires explicit C++ version flag... no
Static linking is disabled.
creating Makefile

current directory: /home/watson/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/charlock_holmes-0.7.9/ext/charlock_holmes
make -j3 DESTDIR\= sitearchdir\=./.gem.20260626-160800-gxh8bu sitelibdir\=./.gem.20260626-160800-gxh8bu clean
make: warning: -j3 forced in submake: resetting jobserver mode.

current directory: /home/watson/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/charlock_holmes-0.7.9/ext/charlock_holmes
make -j3 DESTDIR\= sitearchdir\=./.gem.20260626-160800-gxh8bu sitelibdir\=./.gem.20260626-160800-gxh8bu
make: warning: -j3 forced in submake: resetting jobserver mode.
compiling converter.c
compiling encoding_detector.c
compiling ext.c
compiling transliterator.cpp
In file included from /usr/include/unicode/unistr.h:37,
                 from /usr/include/unicode/translit.h:27,
                 from transliterator.cpp:5:
/usr/include/unicode/char16ptr.h:271:38: error: 'enable_if_t' in namespace 'std' does not name a template type
  271 | template<typename T, typename = std::enable_if_t<std::is_same_v<T, UChar>>>
      |                                      ^~~~~~~~~~~
/usr/include/unicode/char16ptr.h:271:33: note: 'std::enable_if_t' is only available from C++14 onwards
  271 | template<typename T, typename = std::enable_if_t<std::is_same_v<T, UChar>>>
      |                                 ^~~
/usr/include/unicode/char16ptr.h:271:49: error: expected '>' before '<' token
  271 | template<typename T, typename = std::enable_if_t<std::is_same_v<T, UChar>>>
      |                                                 ^
/usr/include/unicode/char16ptr.h: In function 'const char16_t* icu_78::uprv_char16PtrFromUChar(const T*)':
/usr/include/unicode/char16ptr.h:273:24: error: 'is_same_v' is not a member of 'std'; did you mean 'is_same'? [-Wtemplate-body]
  273 |     if constexpr (std::is_same_v<UChar, char16_t>) {
      |                        ^~~~~~~~~
      |                        is_same
/usr/include/unicode/char16ptr.h:273:39: error: expected primary-expression before ',' token [-Wtemplate-body]
  273 |     if constexpr (std::is_same_v<UChar, char16_t>) {
      |                                       ^
/usr/include/unicode/char16ptr.h:273:41: error: expected primary-expression before 'char16_t' [-Wtemplate-body]
  273 |     if constexpr (std::is_same_v<UChar, char16_t>) {
      |                                         ^~~~~~~~
/usr/include/unicode/char16ptr.h:273:40: error: expected ')' before 'char16_t' [-Wtemplate-body]
  273 |     if constexpr (std::is_same_v<UChar, char16_t>) {
      |                  ~                     ^~~~~~~~~
      |                                        )
/usr/include/unicode/char16ptr.h: At global scope:
/usr/include/unicode/char16ptr.h:386:10: error: 'is_convertible_v' is not a member of 'std'; did you mean 'is_convertible'?
  386 |     std::is_convertible_v<T, std::u16string_view>
      |          ^~~~~~~~~~~~~~~~
      |          is_convertible
/usr/include/unicode/char16ptr.h:386:28: error: expected primary-expression before ',' token
  386 |     std::is_convertible_v<T, std::u16string_view>
      |                            ^
/usr/include/unicode/char16ptr.h:400:13: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
  400 | inline std::u16string_view toU16StringView(std::u16string_view sv) { return sv; }
      |             ^~~~~~~~~~~~~~
      |             u16string
/usr/include/unicode/char16ptr.h:408:13: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
  408 | inline std::u16string_view toU16StringView(std::basic_string_view<uint16_t> sv) {
      |             ^~~~~~~~~~~~~~
      |             u16string
/usr/include/unicode/char16ptr.h:429:36: error: 'enable_if_t' in namespace 'std' does not name a template type
  429 |           typename = typename std::enable_if_t<!std::is_pointer_v<std::remove_reference_t<T>>>>
      |                                    ^~~~~~~~~~~
/usr/include/unicode/char16ptr.h:429:36: note: 'std::enable_if_t' is only available from C++14 onwards
/usr/include/unicode/char16ptr.h:429:47: error: expected '>' before '<' token
  429 |           typename = typename std::enable_if_t<!std::is_pointer_v<std::remove_reference_t<T>>>>
      |                                               ^
/usr/include/unicode/char16ptr.h:430:13: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
  430 | inline std::u16string_view toU16StringViewNullable(const T& text) {
      |             ^~~~~~~~~~~~~~
      |             u16string
/usr/include/unicode/char16ptr.h:439:36: error: 'enable_if_t' in namespace 'std' does not name a template type
  439 |           typename = typename std::enable_if_t<std::is_pointer_v<std::remove_reference_t<T>>>,
      |                                    ^~~~~~~~~~~
/usr/include/unicode/char16ptr.h:439:36: note: 'std::enable_if_t' is only available from C++14 onwards
/usr/include/unicode/char16ptr.h:439:47: error: expected '>' before '<' token
  439 |           typename = typename std::enable_if_t<std::is_pointer_v<std::remove_reference_t<T>>>,
      |                                               ^
/usr/include/unicode/char16ptr.h:441:13: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
  441 | inline std::u16string_view toU16StringViewNullable(const T& text) {
      |             ^~~~~~~~~~~~~~
      |             u16string
In file included from /usr/include/unicode/unistr.h:40:
/usr/include/unicode/stringpiece.h:134:29: error: 'enable_if_t' in namespace 'std' does not name a template type
  134 |             typename = std::enable_if_t<
      |                             ^~~~~~~~~~~
/usr/include/unicode/stringpiece.h:134:24: note: 'std::enable_if_t' is only available from C++14 onwards
  134 |             typename = std::enable_if_t<
      |                        ^~~
/usr/include/unicode/stringpiece.h:134:40: error: expected '>' before '<' token
  134 |             typename = std::enable_if_t<
      |                                        ^
/usr/include/unicode/stringpiece.h:185:19: error: expected type-specifier
  185 |   inline operator std::string_view() const {
      |                   ^~~
In file included from /usr/include/unicode/unistr.h:41:
/usr/include/unicode/bytestream.h: In member function 'virtual void icu_78::StringByteSink<StringClass>::Append(const char*, int32_t)':
/usr/include/unicode/bytestream.h:320:24: error: 'is_same_v' is not a member of 'std'; did you mean 'is_same'? [-Wtemplate-body]
  320 |     if constexpr (std::is_same_v<Unit, char>) {
      |                        ^~~~~~~~~
      |                        is_same
/usr/include/unicode/bytestream.h:320:38: error: expected primary-expression before ',' token [-Wtemplate-body]
  320 |     if constexpr (std::is_same_v<Unit, char>) {
      |                                      ^
/usr/include/unicode/bytestream.h:320:40: error: expected primary-expression before 'char' [-Wtemplate-body]
  320 |     if constexpr (std::is_same_v<Unit, char>) {
      |                                        ^~~~
/usr/include/unicode/bytestream.h:320:40: error: expected ')' before 'char' [-Wtemplate-body]
/usr/include/unicode/bytestream.h:320:18: note: to match this '('
  320 |     if constexpr (std::is_same_v<Unit, char>) {
      |                  ^
/usr/include/unicode/unistr.h: At global scope:
/usr/include/unicode/unistr.h:354:40: error: 'enable_if_t' in namespace 'std' does not name a template type
  354 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:354:35: note: 'std::enable_if_t' is only available from C++14 onwards
  354 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:354:51: error: expected '>' before '<' token
  354 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:387:40: error: 'enable_if_t' in namespace 'std' does not name a template type
  387 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:387:35: note: 'std::enable_if_t' is only available from C++14 onwards
  387 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:387:51: error: expected '>' before '<' token
  387 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:1928:37: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
 1928 |   using unspecified_iterator = std::u16string_view::const_iterator;
      |                                     ^~~~~~~~~~~~~~
      |                                     u16string
/usr/include/unicode/unistr.h:1929:45: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
 1929 |   using unspecified_reverse_iterator = std::u16string_view::const_reverse_iterator;
      |                                             ^~~~~~~~~~~~~~
      |                                             u16string
/usr/include/unicode/unistr.h:1937:3: error: 'unspecified_iterator' does not name a type
 1937 |   unspecified_iterator begin() const { return std::u16string_view(*this).begin(); }
      |   ^~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:1943:3: error: 'unspecified_iterator' does not name a type
 1943 |   unspecified_iterator end() const { return std::u16string_view(*this).end(); }
      |   ^~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:1949:3: error: 'unspecified_reverse_iterator' does not name a type
 1949 |   unspecified_reverse_iterator rbegin() const { return std::u16string_view(*this).rbegin(); }
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:1955:3: error: 'unspecified_reverse_iterator' does not name a type
 1955 |   unspecified_reverse_iterator rend() const { return std::u16string_view(*this).rend(); }
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:2021:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 2021 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:2021:35: note: 'std::enable_if_t' is only available from C++14 onwards
 2021 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:2021:51: error: expected '>' before '<' token
 2021 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:2286:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 2286 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:2286:35: note: 'std::enable_if_t' is only available from C++14 onwards
 2286 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:2286:51: error: expected '>' before '<' token
 2286 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:2357:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 2357 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:2357:35: note: 'std::enable_if_t' is only available from C++14 onwards
 2357 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:2357:51: error: expected '>' before '<' token
 2357 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:3101:19: error: expected type-specifier
 3101 |   inline operator std::u16string_view() const {
      |                   ^~~
/usr/include/unicode/unistr.h:3337:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 3337 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:3337:35: note: 'std::enable_if_t' is only available from C++14 onwards
 3337 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:3337:51: error: expected '>' before '<' token
 3337 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:3661:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 3661 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:3661:35: note: 'std::enable_if_t' is only available from C++14 onwards
 3661 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:3661:51: error: expected '>' before '<' token
 3661 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:3816:60: error: 'std::u16string_view' has not been declared; did you mean 'std::u16string'?
 3816 |   static UnicodeString readOnlyAliasFromU16StringView(std::u16string_view text);
      |                                                            ^~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:3932:64: error: 'std::u16string_view' has not been declared; did you mean 'std::u16string'?
 3932 |   UnicodeString& doReplace(int32_t start, int32_t length, std::u16string_view src);
      |                                                                ^~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:3936:32: error: 'std::u16string_view' has not been declared; did you mean 'std::u16string'?
 3936 |   UnicodeString& doAppend(std::u16string_view src);
      |                                ^~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In member function 'bool icu_78::UnicodeString::operator==(const S&) const':
/usr/include/unicode/unistr.h:356:10: error: 'u16string_view' is not a member of 'std'; did you mean 'u16string'? [-Wtemplate-body]
  356 |     std::u16string_view sv(internal::toU16StringView(text));
      |          ^~~~~~~~~~~~~~
      |          u16string
/usr/include/unicode/unistr.h:358:46: error: 'sv' was not declared in this scope [-Wtemplate-body]
  358 |     return !isBogus() && (len = length()) == sv.length() && doEquals(sv.data(), len);
      |                                              ^~
/usr/include/unicode/unistr.h: In member function 'icu_78::UnicodeString& icu_78::UnicodeString::operator=(const S&)':
/usr/include/unicode/unistr.h:2024:45: error: 'toU16StringView' is not a member of 'icu_78::internal' [-Wtemplate-body]
 2024 |     return doReplace(0, length(), internal::toU16StringView(src));
      |                                             ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In member function 'icu_78::UnicodeString& icu_78::UnicodeString::operator+=(const S&)':
/usr/include/unicode/unistr.h:2288:31: error: 'toU16StringView' is not a member of 'icu_78::internal' [-Wtemplate-body]
 2288 |     return doAppend(internal::toU16StringView(src));
      |                               ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In member function 'icu_78::UnicodeString& icu_78::UnicodeString::append(const S&)':
/usr/include/unicode/unistr.h:2359:31: error: 'toU16StringView' is not a member of 'icu_78::internal' [-Wtemplate-body]
 2359 |     return doAppend(internal::toU16StringView(src));
      |                               ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In constructor 'icu_78::UnicodeString::UnicodeString(const S&)':
/usr/include/unicode/unistr.h:3340:24: error: 'toU16StringViewNullable' is not a member of 'icu_78::internal' [-Wtemplate-body]
 3340 |     doAppend(internal::toU16StringViewNullable(text));
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In static member function 'static icu_78::UnicodeString icu_78::UnicodeString::readOnlyAlias(const S&)':
/usr/include/unicode/unistr.h:3663:53: error: 'toU16StringView' is not a member of 'icu_78::internal' [-Wtemplate-body]
 3663 |     return readOnlyAliasFromU16StringView(internal::toU16StringView(text));
      |                                                     ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: At global scope:
/usr/include/unicode/unistr.h:4178:21: error: 'enable_if_t' in namespace 'std' does not name a template type
 4178 |     typename = std::enable_if_t<ConvertibleToU16StringView<S> && std::is_same_v<US, UnicodeString>>>
      |                     ^~~~~~~~~~~
/usr/include/unicode/unistr.h:4178:16: note: 'std::enable_if_t' is only available from C++14 onwards
 4178 |     typename = std::enable_if_t<ConvertibleToU16StringView<S> && std::is_same_v<US, UnicodeString>>>
      |                ^~~
/usr/include/unicode/unistr.h:4178:32: error: expected '>' before '<' token
 4178 |     typename = std::enable_if_t<ConvertibleToU16StringView<S> && std::is_same_v<US, UnicodeString>>>
      |                                ^
/usr/include/unicode/unistr.h: In function 'icu_78::UnicodeString icu_78::operator+(const US&, const S&)':
/usr/include/unicode/unistr.h:4180:46: error: 'toU16StringView' is not a member of 'icu_78::internal' [-Wtemplate-body]
 4180 |   return unistr_internalConcat(s1, internal::toU16StringView(s2));
      |                                              ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: At global scope:
/usr/include/unicode/unistr.h:4186:53: error: 'std::u16string_view' has not been declared; did you mean 'std::u16string'?
 4186 | unistr_internalConcat(const UnicodeString &s1, std::u16string_view s2);
      |                                                     ^~~~~~~~~~~~~~
In file included from /usr/include/unicode/uenum.h:25,
                 from /usr/include/unicode/utrans.h:22,
                 from /usr/include/unicode/translit.h:29:
/usr/include/unicode/localpointer.h:559:26: error: parameter declared 'auto'
  559 | template <typename Type, auto closeFunction>
      |                          ^~~~
/usr/include/unicode/localpointer.h:571:76: error: template argument 2 is invalid [-Wtemplate-body]
  571 |     explicit LocalOpenPointer(std::unique_ptr<Type, decltype(closeFunction)> &&p)
      |                                                                            ^
/usr/include/unicode/localpointer.h:581:78: error: template argument 2 is invalid [-Wtemplate-body]
  581 |     LocalOpenPointer &operator=(std::unique_ptr<Type, decltype(closeFunction)> &&p) {
      |                                                                              ^
/usr/include/unicode/localpointer.h:597:59: error: template argument 2 is invalid [-Wtemplate-body]
  597 |     operator std::unique_ptr<Type, decltype(closeFunction)> () && {
      |                                                           ^
/usr/include/unicode/uenum.h:69:1: note: invalid template non-type parameter
   69 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUEnumerationPointer, UEnumeration, uenum_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/uset.h:362:1: note: invalid template non-type parameter
  362 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUSetPointer, USet, uset_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/unicode/utrans.h:23:
/usr/include/unicode/uset.h:1651:10: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
 1651 |     std::u16string_view operator*() const {
      |          ^~~~~~~~~~~~~~
      |          u16string
/usr/include/unicode/uset.h: In member function 'std::u16string icu_78::header::USetElementIterator::operator*() const':
/usr/include/unicode/uset.h:1771:44: error: no matching function for call to 'uprv_char16PtrFromUChar(const UChar*&)'
 1771 |             return {uprv_char16PtrFromUChar(uchars), static_cast<size_t>(length)};
      |                     ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
  • there is 1 candidate
    • candidate 1: 'template<class T, class> const char16_t* icu_78::uprv_char16PtrFromUChar(const T*)'
      /usr/include/unicode/char16ptr.h:272:24:
        272 | inline const char16_t *uprv_char16PtrFromUChar(const T *p) {
            |                        ^~~~~~~~~~~~~~~~~~~~~~~
      • template argument deduction/substitution failed:
/usr/include/unicode/uset.h:1771:81: error: could not convert '{<expression error>, ((size_t)length)}' from '<brace-enclosed initializer
list>' to 'std::u16string' {aka 'std::__cxx11::basic_string<char16_t>'}
 1771 |             return {uprv_char16PtrFromUChar(uchars), static_cast<size_t>(length)};
      |                                                                                 ^
      |                                                                                 |
      |                                                                                 <brace-enclosed initializer list>
/usr/include/unicode/utrans.h: At global scope:
/usr/include/unicode/utrans.h:258:1: note: invalid template non-type parameter
  258 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUTransliteratorPointer, UTransliterator, utrans_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:243: transliterator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/watson/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/charlock_holmes-0.7.9 for inspection.
Results logged to /home/watson/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/extensions/x86_64-linux/4.0.0/charlock_holmes-0.7.9/gem_make.out

  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/ext/builder.rb:141:in 'Gem::Ext::Builder.run'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/ext/builder.rb:66:in 'block in Gem::Ext::Builder.make'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/ext/builder.rb:58:in 'Array#each'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/ext/builder.rb:58:in 'Gem::Ext::Builder.make'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/ext/ext_conf_builder.rb:44:in 'Gem::Ext::ExtConfBuilder.build'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/ext/builder.rb:220:in 'Gem::Ext::Builder#build_extension'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/ext/builder.rb:252:in 'block in Gem::Ext::Builder#build_extensions'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/ext/builder.rb:251:in 'Array#each'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/ext/builder.rb:251:in 'Gem::Ext::Builder#build_extensions'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems/installer.rb:822:in 'Gem::Installer#build_extensions'
/home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/rubygems_gem_installer.rb:125:in
'Bundler::RubyGemsGemInstaller#build_extensions'
/home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/rubygems_gem_installer.rb:35:in
'Bundler::RubyGemsGemInstaller#install'
/home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/source/rubygems.rb:223:in 'block in
Bundler::Source::Rubygems#install'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/rubygems.rb:1053:in 'Gem.time'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/source/rubygems.rb:222:in 'Bundler::Source::Rubygems#install'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/installer/gem_installer.rb:68:in 'Bundler::GemInstaller#install'
/home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/installer/gem_installer.rb:17:in
'Bundler::GemInstaller#install_from_spec'
/home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/installer/parallel_installer.rb:203:in
'Bundler::ParallelInstaller#do_install'
/home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/installer/parallel_installer.rb:173:in 'block in
Bundler::ParallelInstaller#worker_pool'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/worker.rb:70:in 'Bundler::Worker#apply_func'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/worker.rb:65:in 'block in Bundler::Worker#process_queue'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/worker.rb:56:in 'Kernel#loop'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/worker.rb:56:in 'Bundler::Worker#process_queue'
  /home/watson/.rbenv/versions/4.0.5/lib/ruby/site_ruby/4.0.0/bundler/worker.rb:98:in 'block (2 levels) in Bundler::Worker#create_threads'

An error occurred while installing charlock_holmes (0.7.9), and Bundler cannot continue.

In Gemfile:
  copyright-header was resolved to 1.0.22, which depends on
    github-linguist was resolved to 9.6.0, which depends on
      charlock_holmes
```

```
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/16.1.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /tmp/pkg/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://github.com/CachyOS/CachyOS-PKGBUILDS/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror --disable-fixincludes
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 16.1.1 20260430 (GCC)
```